### PR TITLE
use setup-r-dependencies action for caching workflow des

### DIFF
--- a/validate-submission/validate-submission.yaml
+++ b/validate-submission/validate-submission.yaml
@@ -23,16 +23,13 @@ jobs:
           install-r: false
           use-public-rspm: true
 
-      - name: Install system dependencies
+      - name: Update R
         run: |
           sudo apt-get update
-          sudo apt-get install libcurl4-openssl-dev libv8-dev
 
-      - name: Install HubValidations
-        run: |
-          install.packages("remotes")
-          remotes::install_github("Infectious-Disease-Modeling-Hubs/hubValidations")
-        shell: Rscript {0}
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          packages: Infectious-Disease-Modeling-Hubs/hubValidations, any::sessioninfo
 
       - name: Run validations
         env:
@@ -41,7 +38,8 @@ jobs:
           library("hubValidations")
           v <- hubValidations::validate_pr(
               gh_repo = Sys.getenv("GITHUB_REPOSITORY"),
-              pr_number = Sys.getenv("PR_NUMBER")
+              pr_number = Sys.getenv("PR_NUMBER"),
+              skip_submit_window_check = FALSE
           )
-          hubValidations::check_for_errors(v)
+          hubValidations::check_for_errors(v, verbose = TRUE)
         shell: Rscript {0}


### PR DESCRIPTION
use `setup-r-dependencies` action for installing & caching workflow dependencies

Resolves https://github.com/Infectious-Disease-Modeling-Hubs/hubValidations/issues/30

> YES! Managed to implement caching by including the setup-r-dependecies workflow!
> 
> Been testing out in my fork of FluSight, using this workflow script: https://github.com/annakrystalli/FluSight-forecast-hub/actions/runs/7021327711/workflow?pr=4
> 
> The first time it runs, it's already a bit faster, under 4 mins: https://github.com/annakrystalli/FluSight-forecast-hub/actions/runs/7021198168/attempts/1
> 
> The first time the action succeeds, packages are cached.
> 
> The next time it ran, it completed in under 57s! https://github.com/annakrystalli/FluSight-forecast-hub/actions/runs/7021327711/job/19103122808?pr=4


The workflow also allows for specifying additional dependencies (such as packages required by custom validation functions) through [`setup-r-dependencies` argument `extra-packages`](https://github.com/r-lib/actions/tree/v2-branch/setup-r-dependencies#usage).


