### PR TITLE
Revert pinned versions introduced in #41

### DIFF
--- a/cache-hubval-deps/cache-hubval-deps.yaml
+++ b/cache-hubval-deps/cache-hubval-deps.yaml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: r-lib/actions/setup-r@bd49c52ffe281809afa6f0fecbf37483c5dd0b93 #v2.11.3
+      - uses: r-lib/actions/setup-r@v2
         with:
           install-r: false
           use-public-rspm: true
@@ -30,7 +30,7 @@ jobs:
         run: |
           sudo apt-get update
 
-      - uses: r-lib/actions/setup-r-dependencies@bd49c52ffe281809afa6f0fecbf37483c5dd0b93 #v2.11.3
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           packages: |
             any::hubValidations

--- a/validate-config/validate-config.yaml
+++ b/validate-config/validate-config.yaml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: r-lib/actions/setup-r@bd49c52ffe281809afa6f0fecbf37483c5dd0b93 #v2.11.3
+      - uses: r-lib/actions/setup-r@v2
         with:
           install-r: false
           use-public-rspm: true
@@ -34,7 +34,7 @@ jobs:
         run: |
           sudo apt-get update
 
-      - uses: r-lib/actions/setup-r-dependencies@bd49c52ffe281809afa6f0fecbf37483c5dd0b93 #v2.11.3
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           cache: 'always'
           packages: |
@@ -48,7 +48,7 @@ jobs:
       - name: "Comment on PR"
         id: comment-diff
         if: ${{ github.event_name != 'workflow_dispatch' }}
-        uses: carpentries/actions/comment-diff@2e20fd5ee53b691e27455ce7ca3b16ea885140e8 #v0.15.0
+        uses: carpentries/actions/comment-diff@main
         with:
           pr: ${{ env.PR_NUMBER }}
           path: ${{ runner.temp }}/diff.md

--- a/validate-submission/validate-submission.yaml
+++ b/validate-submission/validate-submission.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: r-lib/actions/setup-r@bd49c52ffe281809afa6f0fecbf37483c5dd0b93 #v2.11.3
+      - uses: r-lib/actions/setup-r@v2
         with:
           install-r: false
           use-public-rspm: true
@@ -32,7 +32,7 @@ jobs:
         run: |
           sudo apt-get update
 
-      - uses: r-lib/actions/setup-r-dependencies@bd49c52ffe281809afa6f0fecbf37483c5dd0b93 #v2.11.3
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           packages: |
             any::hubValidations


### PR DESCRIPTION
These should not be applied to user facing actions as they add maintainance burden and will not include minor and patch updates