### PR TITLE
Add `validate-target-data` workflow / 36

### DIFF
--- a/validate-config/README.md
+++ b/validate-config/README.md
@@ -2,7 +2,7 @@
 
 Ensure Hub configuration files remain valid.
 
-This hubverse action installs the `hubAdmin` package from GitHub using pak as well as required system dependencies.
+This hubverse action installs the `hubAdmin` package from the [hubverse R universe](https://hubverse-org.r-universe.dev/packages) using pak as well as required system dependencies.
 
 It then performs submission validation checks through function `hubAdmin::validate_hub_config()` and assumes you have all three of the required configuration JSON files in your `hub-config/` directory:
 

--- a/validate-submission/README.md
+++ b/validate-submission/README.md
@@ -1,7 +1,7 @@
 # validate-submission
 
 
-This hubverse action installs the `hubValidations` package from GitHub using pak as well as required system dependencies.
+This hubverse action installs the `hubValidations` package from the [hubverse R universe](https://hubverse-org.r-universe.dev/packages) using pak as well as required system dependencies.
 
 It then performs submission validation checks through function `hubValidations::validate_pr()`
 

--- a/validate-target-data/README.md
+++ b/validate-target-data/README.md
@@ -1,0 +1,14 @@
+# validate-target-data
+
+
+This hubverse action installs the `hubValidations` package from the [hubverse R universe](https://hubverse-org.r-universe.dev/packages) using pak as well as required system dependencies.
+
+It then performs target data validation checks through function `hubValidations::validate_target_pr()`
+
+The action is triggered by pull requests onto the `main` branch which add or modify the contents of the following files or directories (excluding `README` files):
+- `target-data/time-series.*`
+- `target-data/time-series/**`
+- `target-data/oracle-output.*`
+- `target-data/oracle-output/**`
+
+For more information on configuring target data validation checks, see the `hubValidations` documentation on the [`validate_target_pr()`](https://hubverse-org.github.io/hubValidations/reference/validate_target_pr.html) function.

--- a/validate-target-data/validate-target-data.yaml
+++ b/validate-target-data/validate-target-data.yaml
@@ -9,11 +9,10 @@ on:
       - 'target-data/time-series/**'
       - 'target-data/oracle-output.*'
       - 'target-data/oracle-output/**'
-    paths-ignore:
-      - '**/README'
-      - '**/README.*'
-      - '**/readme'
-      - '**/readme.*'
+      - '!**/README'
+      - '!**/README.*'
+      - '!**/readme'
+      - '!**/readme.*'
 
 permissions:
   contents: read

--- a/validate-target-data/validate-target-data.yaml
+++ b/validate-target-data/validate-target-data.yaml
@@ -1,0 +1,57 @@
+name: Hub Target Data Validation (R)
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: main
+    paths:
+      - 'target-data/time-series.*'
+      - 'target-data/time-series/**'
+      - 'target-data/oracle-output.*'
+      - 'target-data/oracle-output/**'
+    paths-ignore:
+      - '**/README'
+      - '**/README.*'
+      - '**/readme'
+      - '**/readme.*'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  validate-target-data:
+    runs-on: ubuntu-22.04
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          install-r: false
+          use-public-rspm: true
+          extra-repositories: 'https://hubverse-org.r-universe.dev'
+
+      - name: Update R
+        run: |
+          sudo apt-get update
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          packages: |
+            any::hubValidations
+            any::sessioninfo
+
+      - name: Run target data validations
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          library("hubValidations")
+          v <- hubValidations::validate_target_pr(
+              gh_repo = Sys.getenv("GITHUB_REPOSITORY"),
+              pr_number = Sys.getenv("PR_NUMBER")
+          )
+          hubValidations::check_for_errors(v, verbose = TRUE)
+        shell: Rscript {0}


### PR DESCRIPTION
This PR resolves #36 by adding the `validate-target-data`.

The workflow is based on the validate-submission workflow but is instead triggered by changes in the relevant files/dirs in `target-data` and runs the `validate_target_pr()` function instead of `validate_pr()`.

I also included some minor corrections to the READMEs of the other two R workflows.

‼️ To be functional  (and therefore merged) this PR needs:
- [x] https://github.com/hubverse-org/hubValidations/pull/268 to be merged.
- [x] The `hubValidations`  target data validation functionality to be released.

Post merging, to make the workflow available though `hubCI`
- [ ] A new release to be made in this repo too