### PR TITLE
Update action versions to latest @-tags

### DIFF
--- a/cache-hubval-deps/cache-hubval-deps.yaml
+++ b/cache-hubval-deps/cache-hubval-deps.yaml
@@ -18,7 +18,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/hubverse-aws-upload/hubverse-aws-upload.yaml
+++ b/hubverse-aws-upload/hubverse-aws-upload.yaml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
 
     - name: Get hub cloud config
       # save cloud-related fields from admin config as environment variables
@@ -38,7 +38,7 @@ jobs:
     - name: Configure AWS credentials
       # request credentials to assume the hub's AWS role via OpenID Connect
       if: env.CLOUD_ENABLED == 'true'
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT }}:role/${{ env.CLOUD_STORAGE_LOCATION }}
         aws-region: us-east-1

--- a/validate-config/validate-config.yaml
+++ b/validate-config/validate-config.yaml
@@ -22,7 +22,7 @@ jobs:
       HUB_PATH: ${{ github.workspace }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -48,7 +48,7 @@ jobs:
       - name: "Comment on PR"
         id: comment-diff
         if: ${{ github.event_name != 'workflow_dispatch' }}
-        uses: carpentries/actions/comment-diff@main
+        uses: carpentries/actions/comment-diff@v0.18.0
         with:
           pr: ${{ env.PR_NUMBER }}
           path: ${{ runner.temp }}/diff.md

--- a/validate-submission/validate-submission.yaml
+++ b/validate-submission/validate-submission.yaml
@@ -20,7 +20,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/validate-target-data/validate-target-data.yaml
+++ b/validate-target-data/validate-target-data.yaml
@@ -25,7 +25,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - uses: r-lib/actions/setup-r@v2
         with:


### PR DESCRIPTION
Bumps pinned action versions in the user-facing hub workflow templates. Keeps the deliberate floating `@`-tag pinning policy for this repo (SHA-pinning is reserved for developer workflows).

## Changes
| Action | Before | After | Files |
|---|---|---|---|
| `actions/checkout` | `v5` | `v7` | all five templates |
| `aws-actions/configure-aws-credentials` | `v4` | `v6` | `hubverse-aws-upload/` |
| `carpentries/actions/comment-diff` | `@main` | `@v0.18.0` | `validate-config/` |

`r-lib/actions/*@v2` left as-is (intentional rolling tag).

## Notes for review
- **`configure-aws-credentials` v4 → v6** crosses two majors. The OIDC `role-to-assume` + `aws-region` usage here is unchanged and remains supported in v6, but worth a sanity check against the [v5](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v5.0.0) / [v6](https://github.com/aws-actions/configure-aws-credentials/releases) release notes before merge.
- **`comment-diff@main` → `@v0.18.0`** pins a previously unpinned branch reference (supply-chain hardening). This is independent of the tag-vs-SHA policy.

Resolves #46
