### PR TITLE
Add reusable pr-comment composite action

### DIFF
--- a/.github/workflows/test-pr-comment.yaml
+++ b/.github/workflows/test-pr-comment.yaml
@@ -1,0 +1,151 @@
+name: Test pr-comment action
+
+# Self-tests the pr-comment action (referenced locally) against this PR. One job
+# checks sticky behaviour (create then update-in-place, same comment id); another
+# checks the revision behaviour (same revision edits in place, a new revision
+# reposts a fresh comment). Each cleans up the comment it creates.
+
+on:
+  pull_request:
+    paths:
+      - 'pr-comment/**'
+      - '.github/workflows/test-pr-comment.yaml'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  sticky:
+    # Fork PRs get a read-only GITHUB_TOKEN and cannot post comments, so these
+    # self-tests can only run on same-repo PRs.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Create the sticky comment (via body)
+        id: create
+        uses: ./pr-comment
+        with:
+          pr: ${{ github.event.number }}
+          header: ci-selftest
+          body: "pr-comment self-test: created."
+
+      - name: Write an updated body to a file
+        shell: bash
+        run: |
+          echo "pr-comment self-test: updated via body_path." > "${{ runner.temp }}/comment.md"
+
+      - name: Update the sticky comment (via body_path, same header)
+        id: update
+        uses: ./pr-comment
+        with:
+          pr: ${{ github.event.number }}
+          header: ci-selftest
+          body_path: ${{ runner.temp }}/comment.md
+
+      - name: Assert one comment, updated in place, then clean up
+        uses: actions/github-script@v7
+        env:
+          ID_CREATE: ${{ steps.create.outputs.comment-id }}
+          ID_UPDATE: ${{ steps.update.outputs.comment-id }}
+        with:
+          script: |
+            if (process.env.ID_UPDATE !== process.env.ID_CREATE) {
+              core.setFailed(`sticky update should keep the same comment id: ${process.env.ID_CREATE} -> ${process.env.ID_UPDATE}`);
+              return;
+            }
+            const marker = '<!-- hubverse-comment:ci-selftest -->';
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              ...context.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const mine = comments.filter((c) => c.body && c.body.includes(marker));
+            if (mine.length !== 1) {
+              core.setFailed(`expected exactly 1 sticky comment, found ${mine.length}`);
+              return;
+            }
+            if (!mine[0].body.includes('updated via body_path')) {
+              core.setFailed('sticky comment was not updated in place');
+              return;
+            }
+            await github.rest.issues.deleteComment({ ...context.repo, comment_id: mine[0].id });
+            core.info('sticky self-test passed; test comment removed.');
+
+  revision:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Post at revision A
+        id: a
+        uses: ./pr-comment
+        with:
+          pr: ${{ github.event.number }}
+          header: ci-selftest-revision
+          revision: rev-a
+          body: "revision self-test: A."
+
+      - name: Update at revision A (same revision, edits in place)
+        id: a2
+        uses: ./pr-comment
+        with:
+          pr: ${{ github.event.number }}
+          header: ci-selftest-revision
+          revision: rev-a
+          body: "revision self-test: A updated."
+
+      - name: Post at revision B (new revision, reposts fresh)
+        id: b
+        uses: ./pr-comment
+        with:
+          pr: ${{ github.event.number }}
+          header: ci-selftest-revision
+          revision: rev-b
+          body: "revision self-test: B."
+
+      - name: Assert same-revision edits in place, new revision adds a comment
+        uses: actions/github-script@v7
+        env:
+          ID_A: ${{ steps.a.outputs.comment-id }}
+          ID_A2: ${{ steps.a2.outputs.comment-id }}
+          ID_B: ${{ steps.b.outputs.comment-id }}
+        with:
+          script: |
+            if (process.env.ID_A2 !== process.env.ID_A) {
+              core.setFailed(`same revision should edit in place: ${process.env.ID_A} -> ${process.env.ID_A2}`);
+              return;
+            }
+            if (process.env.ID_B === process.env.ID_A) {
+              core.setFailed('a new revision should post a new comment, but the id was unchanged');
+              return;
+            }
+            const prefix = '<!-- hubverse-comment:ci-selftest-revision:';
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              ...context.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const mine = comments.filter((c) => c.body && c.body.includes(prefix));
+            if (mine.length !== 2) {
+              core.setFailed(`expected 2 comments (one per revision), found ${mine.length}`);
+              return;
+            }
+            const byId = Object.fromEntries(mine.map((c) => [String(c.id), c]));
+            const a = byId[process.env.ID_A];
+            const b = byId[process.env.ID_B];
+            if (!a || !a.body.includes('revision self-test: A updated')) {
+              core.setFailed('revision A comment missing or not updated in place');
+              return;
+            }
+            if (!b || !b.body.includes('revision self-test: B')) {
+              core.setFailed('revision B comment missing or has wrong content');
+              return;
+            }
+            for (const c of mine) {
+              await github.rest.issues.deleteComment({ ...context.repo, comment_id: c.id });
+            }
+            core.info('revision self-test passed; test comments removed.');

--- a/.github/workflows/test-pr-comment.yaml
+++ b/.github/workflows/test-pr-comment.yaml
@@ -3,7 +3,8 @@ name: Test pr-comment action
 # Self-tests the pr-comment action (referenced locally) against this PR. One job
 # checks sticky behaviour (create then update-in-place, same comment id); another
 # checks the revision behaviour (same revision edits in place, a new revision
-# reposts a fresh comment). Each cleans up the comment it creates.
+# reposts a fresh comment); a third checks that invalid headers are rejected.
+# Each cleans up the comment it creates.
 
 on:
   pull_request:
@@ -149,3 +150,44 @@ jobs:
               await github.rest.issues.deleteComment({ ...context.repo, comment_id: c.id });
             }
             core.info('revision self-test passed; test comments removed.');
+
+  invalid-header:
+    # The header guard runs before any API call, so no comment is posted and this
+    # job works on fork PRs too, where the read-only token blocks the jobs above.
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Omitted header
+        id: omitted
+        continue-on-error: true
+        uses: ./pr-comment
+        with:
+          pr: ${{ github.event.number }}
+          body: "invalid-header self-test: must never be posted."
+
+      - name: Header containing a colon
+        id: colon
+        continue-on-error: true
+        uses: ./pr-comment
+        with:
+          pr: ${{ github.event.number }}
+          header: "ci-selftest:not-a-slug"
+          body: "invalid-header self-test: must never be posted."
+
+      - name: Assert both were rejected
+        shell: bash
+        env:
+          OMITTED: ${{ steps.omitted.outcome }}
+          COLON: ${{ steps.colon.outcome }}
+        run: |
+          status=0
+          if [ "$OMITTED" != failure ]; then
+            echo "an omitted header should fail the step, got: $OMITTED"
+            status=1
+          fi
+          if [ "$COLON" != failure ]; then
+            echo "a header containing ':' should fail the step, got: $COLON"
+            status=1
+          fi
+          exit "$status"

--- a/pr-comment/README.md
+++ b/pr-comment/README.md
@@ -32,7 +32,7 @@ steps:
 | Input | Default | Description |
 |---|---|---|
 | `pr` | *(required)* | Pull request number to comment on. |
-| `header` | *(required)* | Unique key for this comment; each header owns one sticky comment. |
+| `header` | *(required)* | Unique key for this comment; each header owns one sticky comment. Must be a slug of letters, digits, `-` or `_`. |
 | `body` | *(empty)* | Comment body (markdown). Provide this or `body_path`. |
 | `body_path` | *(empty)* | Path to a file holding the body. Takes precedence over `body`. |
 | `revision` | *(empty)* | Optional key (e.g. the PR head commit SHA) enabling per-revision comments. See [Notifying on changes](#notifying-on-changes). |
@@ -72,8 +72,9 @@ artifact instead of the event context.
 
 ## Notes
 
-- `header` should be a simple slug (letters, digits, `-`, `_`); it is embedded in
-  an HTML comment marker used to find the comment again.
+- `header` must be a slug of letters, digits, `-` or `_`; it is embedded in an
+  HTML comment marker used to find the comment again. Anything else fails the
+  step.
 - Create-or-update is not atomic. Two runs with the same `header` racing on one
   PR can each create a comment, so callers that may fire concurrently should
   serialise with a workflow [`concurrency`](https://docs.github.com/actions/using-jobs/using-concurrency)

--- a/pr-comment/README.md
+++ b/pr-comment/README.md
@@ -1,0 +1,96 @@
+# pr-comment
+
+Creates or updates a **single** pull request comment identified by a marker key.
+Each distinct `header` keeps its own sticky comment on a PR, so re-running a
+workflow updates its comment in place and independent workflows never clobber
+each other's.
+
+It wraps [`actions/github-script`](https://github.com/actions/github-script) —
+no external dependencies — and embeds a hidden marker
+(`<!-- hubverse-comment:<header> -->`, with the `revision` appended when set) in
+the comment to find it again on the next run, paging through all PR comments so it
+works on long threads.
+
+## Usage
+
+The caller needs `permissions: pull-requests: write`.
+
+```yaml
+permissions:
+  pull-requests: write
+
+steps:
+  - uses: hubverse-org/hubverse-actions/pr-comment@main
+    with:
+      pr: ${{ github.event.number }}
+      header: submission-validation
+      body_path: ${{ runner.temp }}/results.md
+```
+
+## Inputs
+
+| Input | Default | Description |
+|---|---|---|
+| `pr` | *(required)* | Pull request number to comment on. |
+| `header` | *(required)* | Unique key for this comment; each header owns one sticky comment. |
+| `body` | *(empty)* | Comment body (markdown). Provide this or `body_path`. |
+| `body_path` | *(empty)* | Path to a file holding the body. Takes precedence over `body`. |
+| `revision` | *(empty)* | Optional key (e.g. the PR head commit SHA) enabling per-revision comments. See [Notifying on changes](#notifying-on-changes). |
+| `token` | `${{ github.token }}` | Token used to read and write PR comments. |
+
+## Outputs
+
+| Output | Description |
+|---|---|
+| `comment-id` | ID of the comment that was created or updated. |
+
+## Notifying on changes
+
+Without `revision`, the action keeps a **single** comment per `header` and edits
+it in place. GitHub sends no notification for an edit, so this is quiet — good for
+CI that updates often, but a submitter is not pinged when a re-run changes the
+result.
+
+Set `revision` (typically the PR head commit SHA) to post a **new** comment when
+the revision changes — which notifies — while a re-run on the **same** revision
+edits that revision's comment in place. Earlier revisions' comments are left
+untouched, so the PR accumulates a history of results across commits.
+
+```yaml
+- uses: hubverse-org/hubverse-actions/pr-comment@main
+  with:
+    pr: ${{ github.event.number }}
+    header: submission-validation
+    revision: ${{ github.event.pull_request.head.sha }}
+    body_path: ${{ runner.temp }}/results.md
+```
+
+Use `github.event.pull_request.head.sha` (the submitted commit), not `github.sha`
+(the temporary merge commit, which changes on every base update). In the fork-safe
+`workflow_run` pattern below, the PR number and head SHA come from the uploaded
+artifact instead of the event context.
+
+## Notes
+
+- `header` should be a simple slug (letters, digits, `-`, `_`); it is embedded in
+  an HTML comment marker used to find the comment again.
+- Create-or-update is not atomic. Two runs with the same `header` racing on one
+  PR can each create a comment, so callers that may fire concurrently should
+  serialise with a workflow [`concurrency`](https://docs.github.com/actions/using-jobs/using-concurrency)
+  group.
+
+## Posting from fork pull requests
+
+A `pull_request` workflow triggered from a **fork** gets a read-only
+`GITHUB_TOKEN` — GitHub downgrades `pull-requests: write` and withholds secrets —
+so it cannot post comments. Since most submissions to a hub come from forks, this
+action must be invoked from a workflow that runs in the **base repository's**
+context with a write token.
+
+The recommended pattern is a two-stage
+[`workflow_run`](https://docs.github.com/actions/using-workflows/events-that-trigger-workflows#workflow_run)
+split: the `pull_request` workflow does the read-only work and uploads its result
+(plus the PR number) as an artifact; a `workflow_run` workflow downloads the
+artifact and calls this action to post. Avoid `pull_request_target` for anything
+that checks out or acts on PR content — it exposes the write token to
+submitter-controlled code.

--- a/pr-comment/action.yaml
+++ b/pr-comment/action.yaml
@@ -12,6 +12,7 @@ inputs:
     description: >-
       Unique key identifying this comment. Each distinct header keeps its own
       sticky comment on the PR, so different workflows do not clobber each other.
+      Must be a slug of letters, digits, `-` or `_`.
     required: true
   body:
     description: "Comment body (markdown). Provide this or body_path."
@@ -53,6 +54,10 @@ runs:
           const fs = require('fs');
           const header = process.env.HEADER;
           const revision = process.env.REVISION;
+          if (!/^[A-Za-z0-9_-]+$/.test(header)) {
+            core.setFailed(`pr-comment: \`header\` must be a slug of letters, digits, \`-\` or \`_\`; got "${header}".`);
+            return;
+          }
           // Fold the revision into the marker: a new revision yields a new marker,
           // so no existing comment matches and a fresh comment is posted, leaving
           // earlier revisions' comments in place. Same revision (or none) matches

--- a/pr-comment/action.yaml
+++ b/pr-comment/action.yaml
@@ -1,0 +1,97 @@
+name: "Upsert a PR comment"
+description: >-
+  Create or update a single pull request comment identified by a marker key, so
+  each workflow reliably owns and updates its own comment.
+author: "hubverse"
+
+inputs:
+  pr:
+    description: "Pull request number to comment on."
+    required: true
+  header:
+    description: >-
+      Unique key identifying this comment. Each distinct header keeps its own
+      sticky comment on the PR, so different workflows do not clobber each other.
+    required: true
+  body:
+    description: "Comment body (markdown). Provide this or body_path."
+    default: ""
+  body_path:
+    description: "Path to a file holding the comment body. Takes precedence over body."
+    default: ""
+  revision:
+    description: >-
+      Optional revision key, e.g. the PR head commit SHA. When it changes, a new
+      comment is posted (which notifies) and earlier revisions' comments are left
+      in place, building a history across commits; a re-run with the same revision
+      edits that revision's comment in place. When unset, a single comment is kept
+      and edited in place.
+    default: ""
+  token:
+    description: "Token used to read and write PR comments."
+    default: ${{ github.token }}
+
+outputs:
+  comment-id:
+    description: "ID of the comment that was created or updated."
+    value: ${{ steps.comment.outputs.comment-id }}
+
+runs:
+  using: composite
+  steps:
+    - id: comment
+      uses: actions/github-script@v7
+      env:
+        PR: ${{ inputs.pr }}
+        HEADER: ${{ inputs.header }}
+        BODY: ${{ inputs.body }}
+        BODY_PATH: ${{ inputs.body_path }}
+        REVISION: ${{ inputs.revision }}
+      with:
+        github-token: ${{ inputs.token }}
+        script: |
+          const fs = require('fs');
+          const header = process.env.HEADER;
+          const revision = process.env.REVISION;
+          // Fold the revision into the marker: a new revision yields a new marker,
+          // so no existing comment matches and a fresh comment is posted, leaving
+          // earlier revisions' comments in place. Same revision (or none) matches
+          // and edits in place.
+          const marker = `<!-- hubverse-comment:${header}${revision ? `:${revision}` : ''} -->`;
+
+          const bodyPath = process.env.BODY_PATH;
+          if (bodyPath && !fs.existsSync(bodyPath)) {
+            core.setFailed(`pr-comment: body_path not found: ${bodyPath}`);
+            return;
+          }
+          const raw = bodyPath ? fs.readFileSync(bodyPath, 'utf8') : process.env.BODY;
+          if (!raw.trim()) {
+            core.setFailed('pr-comment: empty body (set `body` or `body_path`).');
+            return;
+          }
+          const body = `${marker}\n${raw}`;
+
+          const issue_number = Number(process.env.PR);
+          if (!Number.isInteger(issue_number) || issue_number <= 0) {
+            core.setFailed(`pr-comment: invalid pr number "${process.env.PR}".`);
+            return;
+          }
+
+          const comments = await github.paginate(github.rest.issues.listComments, {
+            ...context.repo,
+            issue_number,
+            per_page: 100,
+          });
+          const existing = comments.find((c) => c.body && c.body.includes(marker));
+
+          let id;
+          if (existing) {
+            await github.rest.issues.updateComment({ ...context.repo, comment_id: existing.id, body });
+            id = existing.id;
+            core.info(`Updated comment ${id} (header: ${header}).`);
+          } else {
+            const { data } = await github.rest.issues.createComment({ ...context.repo, issue_number, body });
+            id = data.id;
+            core.info(`Created comment ${id} (header: ${header}).`);
+          }
+          core.setOutput('comment-id', id);


### PR DESCRIPTION
Resolves #52.

Adds a `pr-comment` composite action that upserts a single PR comment identified by a marker key, so each workflow owns its own comment with no external dependency (it wraps `actions/github-script`). It's the poster that submission validation (#53) will use.

## Why a new action

We already use `carpentries/actions/comment-diff` (in `validate-config`), but it matches the **first** `github-actions[bot]` comment on the PR with no per-comment identity — so independent workflows clobber each other's comments — it caps its scan at 300 comments, and it's a third-party dependency pinned at a version that differs from its own `main`. `pr-comment` fixes all three with an explicit `header` marker and no external dependency, and adds the per-revision behaviour we want for submission validation. It can later replace carpentries in `validate-config` too.

## What it does

- Keyed by `header`: each distinct header keeps its own sticky comment; re-runs edit it in place, and independent workflows never clobber each other.
- Optional `revision` (e.g. the PR head commit SHA): when it changes, a **new** comment is posted — notifying the submitter — while a re-run on the **same** revision edits in place and earlier revisions' comments are kept, giving a history of results across commits.
- `body` or `body_path` input; `comment-id` output.
- Marker `<!-- hubverse-comment:<header>[:<revision>] -->`, found by paging all PR comments.

## Testing

`.github/workflows/test-pr-comment.yaml` self-tests against this PR: a **sticky** job (create → update-in-place, asserting the same comment id) and a **revision** job (same revision edits in place; a new revision adds a second comment).

## Notes

- Fork PRs get a read-only token, so this must be invoked from a base-repo-context workflow (the `workflow_run` pattern) — documented in the README; #53 wires that up.
- Follow-up: migrate `validate-config` off `carpentries/actions/comment-diff` onto this action.
