### PR TITLE
Proposal: in validate-submission, allow user to configure install-r in setup-r

### DIFF
--- a/validate-submission/action.yaml
+++ b/validate-submission/action.yaml
@@ -63,6 +63,11 @@ inputs:
   extra_repositories:
     description: "Extra R package repositories passed to setup-r."
     default: "https://hubverse-org.r-universe.dev"
+  install_r: 
+    description: >-
+      Download and install R (true) or defer to an installation already present on the runner
+      (false)? Passed to setup-r.
+    default: false
   github_token:
     description: "Token used to read pull request files via the GitHub API."
     default: ${{ github.token }}
@@ -72,7 +77,7 @@ runs:
   steps:
     - uses: r-lib/actions/setup-r@v2
       with:
-        install-r: false
+        install-r: ${{ inputs.install_r }}
         use-public-rspm: true
         extra-repositories: ${{ inputs.extra_repositories }}
 


### PR DESCRIPTION
This will make it possible to use GHA runners that do not have a pre-installed R.

We tend to use `ubuntu-latest` for our CI in the COVIDHub and RSVHub (which lacks a pre-installed R). Adding this is a nice to have for us (versus either switching to the ubuntu 22 runner for this particular workflow or adding a separate install R step upstream)