### PR TITLE
Post submission validation results to the PR

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,29 @@
+# .github/workflows
+
+Two unrelated kinds of file share this directory, because GitHub only recognises
+workflows in `.github/workflows/` — they cannot live in subdirectories the way
+actions can.
+
+## Shipped to hubs
+
+Reusable workflows that hubs call, and part of this repository's public surface.
+Changing one changes behaviour in every hub using it, and they move to the release
+tag along with the actions.
+
+| | |
+|---|---|
+| `post-validation-comment.yaml` | Posts a validation result to the pull request it came from. Called by the [`validate-submission`](../../validate-submission) template; written to suit the other `validate-*` actions as they adopt the same pattern. |
+
+## This repository's own CI
+
+Everything prefixed `test-`. These run against pull requests here and are not
+consumed by anyone.
+
+| | |
+|---|---|
+| `test-pr-comment.yaml` | Self-tests [`pr-comment`](../../pr-comment) against the pull request it runs on. |
+| `test-validate-submission.yaml` | Runs [`validate-submission`](../../validate-submission) against fixture PRs in `ci-testhub-simple`, and its summary rendering against bundled test hubs. |
+| `test-submission-comment.yaml` | Exercises the upload-then-comment handoff, calling the same reusable workflow the template calls. |
+
+If you add a reusable workflow here, add it to the first table. If you add CI,
+prefix it `test-` so the distinction keeps holding.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -23,7 +23,8 @@ consumed by anyone.
 |---|---|
 | `test-pr-comment.yaml` | Self-tests [`pr-comment`](../../pr-comment) against the pull request it runs on. |
 | `test-validate-submission.yaml` | Runs [`validate-submission`](../../validate-submission) against fixture PRs in `ci-testhub-simple`, and its summary rendering against bundled test hubs. |
-| `test-submission-comment.yaml` | Exercises the upload-then-comment handoff, calling the same reusable workflow the template calls. |
+| `test-submission-comment.yaml` | Stage 1 of the handoff self-test: uploads a stub result. |
+| `test-submission-comment-post.yaml` | Stage 2: listens for the above finishing and calls the same shared workflow a hub calls. Split in two because a workflow cannot listen to itself. |
 
 If you add a reusable workflow here, add it to the first table. If you add CI,
 prefix it `test-` so the distinction keeps holding.

--- a/.github/workflows/post-validation-comment.yaml
+++ b/.github/workflows/post-validation-comment.yaml
@@ -1,0 +1,84 @@
+name: Post a validation result to its pull request
+
+# Shipped to hubs, not this repository's own CI — see the README in this
+# directory for why the two sit side by side.
+#
+# Reusable half of the fork-safe commenting pattern. A `pull_request` workflow
+# triggered from a fork gets a read-only GITHUB_TOKEN and cannot comment, so it
+# uploads its result as an artifact and a `workflow_run` job calls this, which
+# runs in the base repository's context with a write token.
+#
+# Called like this, from a workflow that triggers on its own completion:
+#
+#   comment:
+#     if: github.event_name == 'workflow_run'
+#     uses: hubverse-org/hubverse-actions/.github/workflows/post-validation-comment.yaml@main
+#     permissions:
+#       contents: read
+#       actions: read
+#       pull-requests: write
+#
+# Everything below is referenced at @main rather than copied into a hub, so gate
+# expressions, action pins and the concurrency key stay fixable in one place.
+
+on:
+  workflow_call:
+    inputs:
+      artifact_name:
+        description: >-
+          Artifact the triggering run uploaded the result as. Must match the
+          `artifact_name` the producing action uploaded it under.
+        type: string
+        default: submission-validation-results
+      body_file:
+        description: "File within that artifact holding the comment body."
+        type: string
+        default: summary.md
+      header:
+        description: "pr-comment key; each header owns one sticky comment per revision."
+        type: string
+        default: submission-validation
+
+jobs:
+  comment:
+    # Skipped on the workflow_run that the calling run triggers in turn, which is
+    # where the chain stops.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      contains(fromJSON('["success", "failure"]'), github.event.workflow_run.conclusion)
+    runs-on: ubuntu-22.04
+    # Serialise re-runs of one revision: pr-comment's create-or-update is not
+    # atomic, so two of them finishing together could each post a comment. Keyed
+    # on the commit rather than the branch because runs for different revisions
+    # write different comments and never race — and because a group holds only
+    # one pending run, so a branch-wide key would cancel a middle commit's
+    # comment before it posted.
+    concurrency:
+      group: ${{ inputs.header }}-${{ github.event.workflow_run.head_sha }}
+      cancel-in-progress: false
+    steps:
+      - name: Download the result
+        uses: actions/download-artifact@v5
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: result
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      # A fork pull request runs its own copy of the triggering workflow, so
+      # everything in the artifact is submitter-controlled. The target pull
+      # request is therefore resolved from the trigger, never from the artifact.
+      # Empty when the pull request has since been closed.
+      - name: Resolve the pull request from the trigger
+        id: pr
+        uses: hubverse-org/hubverse-actions/resolve-pr@main
+
+      - if: steps.pr.outputs.number != ''
+        uses: hubverse-org/hubverse-actions/pr-comment@main
+        with:
+          pr: ${{ steps.pr.outputs.number }}
+          header: ${{ inputs.header }}
+          # Keying on the submitted commit posts a fresh comment per revision,
+          # which notifies the submitter, and keeps earlier results on the thread.
+          revision: ${{ github.event.workflow_run.head_sha }}
+          body_path: result/${{ inputs.body_file }}

--- a/.github/workflows/post-validation-comment.yaml
+++ b/.github/workflows/post-validation-comment.yaml
@@ -8,15 +8,21 @@ name: Post a validation result to its pull request
 # uploads its result as an artifact and a `workflow_run` job calls this, which
 # runs in the base repository's context with a write token.
 #
-# Called like this, from a workflow that triggers on its own completion:
+# Called from a second workflow that listens for the first one completing — a
+# workflow cannot listen to itself, so this always takes two files in the hub:
 #
-#   comment:
-#     if: github.event_name == 'workflow_run'
-#     uses: hubverse-org/hubverse-actions/.github/workflows/post-validation-comment.yaml@main
-#     permissions:
-#       contents: read
-#       actions: read
-#       pull-requests: write
+#   on:
+#     workflow_run:
+#       workflows: ["<the workflow that produced the result>"]
+#       types: [completed]
+#
+#   jobs:
+#     comment:
+#       uses: hubverse-org/hubverse-actions/.github/workflows/post-validation-comment.yaml@main
+#       permissions:
+#         contents: read
+#         actions: read
+#         pull-requests: write
 #
 # Everything below is referenced at @main rather than copied into a hub, so gate
 # expressions, action pins and the concurrency key stay fixable in one place.
@@ -57,7 +63,12 @@ jobs:
       group: ${{ inputs.header }}-${{ github.event.workflow_run.head_sha }}
       cancel-in-progress: false
     steps:
+      # Tolerated rather than fatal: a hub that turns the summary off but leaves
+      # this workflow in place would otherwise get a red run on every pull
+      # request. Handled here, where it is fixable, rather than in a README row.
       - name: Download the result
+        id: download
+        continue-on-error: true
         uses: actions/download-artifact@v5
         with:
           name: ${{ inputs.artifact_name }}
@@ -65,15 +76,19 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}
 
+      - if: steps.download.outcome == 'failure'
+        run: echo "::notice::No '${{ inputs.artifact_name }}' artifact on the triggering run — nothing to post."
+
       # A fork pull request runs its own copy of the triggering workflow, so
       # everything in the artifact is submitter-controlled. The target pull
       # request is therefore resolved from the trigger, never from the artifact.
       # Empty when the pull request has since been closed.
       - name: Resolve the pull request from the trigger
         id: pr
+        if: steps.download.outcome == 'success'
         uses: hubverse-org/hubverse-actions/resolve-pr@main
 
-      - if: steps.pr.outputs.number != ''
+      - if: steps.download.outcome == 'success' && steps.pr.outputs.number != ''
         uses: hubverse-org/hubverse-actions/pr-comment@main
         with:
           pr: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/test-pr-comment.yaml
+++ b/.github/workflows/test-pr-comment.yaml
@@ -3,7 +3,7 @@ name: Test pr-comment action
 # Self-tests the pr-comment action (referenced locally) against this PR. One job
 # checks sticky behaviour (create then update-in-place, same comment id); another
 # checks the revision behaviour (same revision edits in place, a new revision
-# reposts a fresh comment); a third checks that invalid headers are rejected.
+# reposts a fresh comment); a third checks that invalid inputs are rejected.
 # Each cleans up the comment it creates.
 
 on:
@@ -172,8 +172,8 @@ jobs:
               core.setFailed('a SHA revision should be abbreviated in the footer');
               return;
             }
-            for (const c of mine) {
-              await github.rest.issues.deleteComment({ ...context.repo, comment_id: c.id });
+            for (const comment of mine) {
+              await github.rest.issues.deleteComment({ ...context.repo, comment_id: comment.id });
             }
             core.info('revision self-test passed; test comments removed.');
 
@@ -221,16 +221,12 @@ jobs:
           REVISION: ${{ steps.revision.outcome }}
         run: |
           status=0
-          if [ "$OMITTED" != failure ]; then
-            echo "an omitted header should fail the step, got: $OMITTED"
+          check() {
+            [ "$2" = failure ] && return 0
+            echo "$1 should fail the step, got: $2"
             status=1
-          fi
-          if [ "$COLON" != failure ]; then
-            echo "a header containing ':' should fail the step, got: $COLON"
-            status=1
-          fi
-          if [ "$REVISION" != failure ]; then
-            echo "a revision containing '-->' should fail the step, got: $REVISION"
-            status=1
-          fi
+          }
+          check "an omitted header" "$OMITTED"
+          check "a header containing ':'" "$COLON"
+          check "a revision containing '-->'" "$REVISION"
           exit "$status"

--- a/.github/workflows/test-pr-comment.yaml
+++ b/.github/workflows/test-pr-comment.yaml
@@ -72,6 +72,10 @@ jobs:
               core.setFailed('sticky comment was not updated in place');
               return;
             }
+            if (mine[0].body.includes('Results for')) {
+              core.setFailed('a comment posted without a revision should carry no revision footer');
+              return;
+            }
             await github.rest.issues.deleteComment({ ...context.repo, comment_id: mine[0].id });
             core.info('sticky self-test passed; test comment removed.');
 
@@ -108,12 +112,23 @@ jobs:
           revision: rev-b
           body: "revision self-test: B."
 
+      # Production always passes a commit SHA, so cover the abbreviated form too.
+      - name: Post at a revision that is a commit SHA
+        id: c
+        uses: ./pr-comment
+        with:
+          pr: ${{ github.event.number }}
+          header: ci-selftest-revision
+          revision: 0123456789abcdef0123456789abcdef01234567
+          body: "revision self-test: C."
+
       - name: Assert same-revision edits in place, new revision adds a comment
         uses: actions/github-script@v7
         env:
           ID_A: ${{ steps.a.outputs.comment-id }}
           ID_A2: ${{ steps.a2.outputs.comment-id }}
           ID_B: ${{ steps.b.outputs.comment-id }}
+          ID_C: ${{ steps.c.outputs.comment-id }}
         with:
           script: |
             if (process.env.ID_A2 !== process.env.ID_A) {
@@ -131,13 +146,14 @@ jobs:
               per_page: 100,
             });
             const mine = comments.filter((c) => c.body && c.body.includes(prefix));
-            if (mine.length !== 2) {
-              core.setFailed(`expected 2 comments (one per revision), found ${mine.length}`);
+            if (mine.length !== 3) {
+              core.setFailed(`expected 3 comments (one per revision), found ${mine.length}`);
               return;
             }
             const byId = Object.fromEntries(mine.map((c) => [String(c.id), c]));
             const a = byId[process.env.ID_A];
             const b = byId[process.env.ID_B];
+            const c = byId[process.env.ID_C];
             if (!a || !a.body.includes('revision self-test: A updated')) {
               core.setFailed('revision A comment missing or not updated in place');
               return;
@@ -146,13 +162,23 @@ jobs:
               core.setFailed('revision B comment missing or has wrong content');
               return;
             }
+            // Each comment says which revision it is for, since the marker that
+            // tells them apart is invisible.
+            if (!a.body.includes('Results for revision `rev-a`')) {
+              core.setFailed('revision A comment is missing its revision footer');
+              return;
+            }
+            if (!c || !c.body.includes('Results for commit `0123456`')) {
+              core.setFailed('a SHA revision should be abbreviated in the footer');
+              return;
+            }
             for (const c of mine) {
               await github.rest.issues.deleteComment({ ...context.repo, comment_id: c.id });
             }
             core.info('revision self-test passed; test comments removed.');
 
-  invalid-header:
-    # The header guard runs before any API call, so no comment is posted and this
+  invalid-inputs:
+    # The input guards run before any API call, so no comment is posted and this
     # job works on fork PRs too, where the read-only token blocks the jobs above.
     runs-on: ubuntu-22.04
     steps:
@@ -175,11 +201,24 @@ jobs:
           header: "ci-selftest:not-a-slug"
           body: "invalid-header self-test: must never be posted."
 
-      - name: Assert both were rejected
+      # A revision carrying `-->` would close the marker early and spill the rest
+      # of the comment into the rendered body.
+      - name: Revision that would break out of the marker
+        id: revision
+        continue-on-error: true
+        uses: ./pr-comment
+        with:
+          pr: ${{ github.event.number }}
+          header: ci-selftest-bad-revision
+          revision: "abc --> <script>"
+          body: "invalid-input self-test: must never be posted."
+
+      - name: Assert all were rejected
         shell: bash
         env:
           OMITTED: ${{ steps.omitted.outcome }}
           COLON: ${{ steps.colon.outcome }}
+          REVISION: ${{ steps.revision.outcome }}
         run: |
           status=0
           if [ "$OMITTED" != failure ]; then
@@ -188,6 +227,10 @@ jobs:
           fi
           if [ "$COLON" != failure ]; then
             echo "a header containing ':' should fail the step, got: $COLON"
+            status=1
+          fi
+          if [ "$REVISION" != failure ]; then
+            echo "a revision containing '-->' should fail the step, got: $REVISION"
             status=1
           fi
           exit "$status"

--- a/.github/workflows/test-submission-comment-post.yaml
+++ b/.github/workflows/test-submission-comment-post.yaml
@@ -1,0 +1,65 @@
+name: Test submission comment flow (post)
+
+# Stage 2 of the self-test, and the same shape a hub uses: a separate workflow
+# listening for the first one finishing, calling the shared workflow that hubs
+# call. So this exercises the real posting path rather than a copy of it.
+#
+# It only starts working once on the default branch, since `workflow_run` fires
+# only for workflow files already there. The `verify` job asserts the comment
+# landed on the right pull request and removes it.
+
+on:
+  workflow_run:
+    workflows: ["Test submission comment flow"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  comment:
+    uses: ./.github/workflows/post-validation-comment.yaml
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
+    with:
+      artifact_name: comment-flow-selftest
+      header: ci-comment-flow
+
+  verify:
+    needs: comment
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - id: pr
+        uses: hubverse-org/hubverse-actions/resolve-pr@main
+
+      - name: Assert it landed on the right pull request, then clean up
+        if: steps.pr.outputs.number != ''
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        with:
+          script: |
+            const issue_number = Number(process.env.PR_NUMBER);
+            const marker = `<!-- hubverse-comment:ci-comment-flow:${process.env.HEAD_SHA} -->`;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              ...context.repo,
+              issue_number,
+              per_page: 100,
+            });
+            const mine = comments.filter((c) => c.body && c.body.includes(marker));
+            if (mine.length !== 1) {
+              core.setFailed(`expected exactly 1 comment on PR ${issue_number}, found ${mine.length}`);
+              return;
+            }
+            if (!mine[0].body.includes('comment-flow self-test')) {
+              core.setFailed('the posted comment does not carry the stub summary');
+              return;
+            }
+            await github.rest.issues.deleteComment({ ...context.repo, comment_id: mine[0].id });
+            core.info(`comment flow self-test passed on PR ${issue_number}; test comment removed.`);

--- a/.github/workflows/test-submission-comment-post.yaml
+++ b/.github/workflows/test-submission-comment-post.yaml
@@ -28,6 +28,10 @@ jobs:
       header: ci-comment-flow
 
   verify:
+    # Only assert a comment exists when stage 1 actually uploaded one. If it
+    # failed before the upload, the comment job correctly posts nothing and its
+    # own red run is the signal — asserting here would just double-report it.
+    if: github.event.workflow_run.conclusion == 'success'
     needs: comment
     runs-on: ubuntu-22.04
     permissions:

--- a/.github/workflows/test-submission-comment.yaml
+++ b/.github/workflows/test-submission-comment.yaml
@@ -1,0 +1,105 @@
+name: Test submission comment flow
+
+# Mirrors what validate-submission's template does — a `pull_request` job that
+# uploads an artifact, and a `workflow_run` job triggered by this workflow's own
+# completion that posts it — but stubs the result instead of running a
+# validation. The posting job calls the same reusable workflow the template
+# calls, so this exercises the real thing rather than a copy of it.
+#
+# Two things to know when reading a run of this:
+#
+# - `workflow_run` only fires for workflow files already on the default branch,
+#   so on the pull request that changes this file only the `upload` job runs.
+#   The rest exercises whatever is on main.
+# - Each run is followed by another with every job skipped, because this workflow
+#   triggers on its own completion. GitHub caps `workflow_run` chains at three
+#   levels, so it stops there. That skipped run is the template's behaviour too.
+
+on:
+  pull_request:
+    paths:
+      - 'validate-submission/**'
+      - 'pr-comment/**'
+      - 'resolve-pr/**'
+      - '.github/workflows/post-validation-comment.yaml'
+      - '.github/workflows/test-submission-comment.yaml'
+  workflow_run:
+    workflows: ["Test submission comment flow"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  upload:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Stand in for a validation summary
+        shell: bash
+        env:
+          RESULT_DIR: ${{ runner.temp }}/result
+        run: |
+          mkdir -p "$RESULT_DIR"
+          cat > "$RESULT_DIR/summary.md" <<'EOF'
+          ## Submission validation
+
+          comment-flow self-test: this comment is posted and removed by CI.
+          EOF
+
+      - name: Upload the stub summary
+        uses: actions/upload-artifact@v5
+        with:
+          name: comment-flow-selftest
+          path: ${{ runner.temp }}/result
+          if-no-files-found: error
+          retention-days: 1
+
+  comment:
+    if: github.event_name == 'workflow_run'
+    uses: ./.github/workflows/post-validation-comment.yaml
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
+    with:
+      artifact_name: comment-flow-selftest
+      header: ci-comment-flow
+
+  verify:
+    if: github.event_name == 'workflow_run'
+    needs: comment
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - id: pr
+        uses: hubverse-org/hubverse-actions/resolve-pr@main
+
+      - name: Assert it landed on the right pull request, then clean up
+        if: steps.pr.outputs.number != ''
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        with:
+          script: |
+            const issue_number = Number(process.env.PR_NUMBER);
+            const marker = `<!-- hubverse-comment:ci-comment-flow:${process.env.HEAD_SHA} -->`;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              ...context.repo,
+              issue_number,
+              per_page: 100,
+            });
+            const mine = comments.filter((c) => c.body && c.body.includes(marker));
+            if (mine.length !== 1) {
+              core.setFailed(`expected exactly 1 comment on PR ${issue_number}, found ${mine.length}`);
+              return;
+            }
+            if (!mine[0].body.includes('comment-flow self-test')) {
+              core.setFailed('the posted comment does not carry the stub summary');
+              return;
+            }
+            await github.rest.issues.deleteComment({ ...context.repo, comment_id: mine[0].id });
+            core.info(`comment flow self-test passed on PR ${issue_number}; test comment removed.`);

--- a/.github/workflows/test-submission-comment.yaml
+++ b/.github/workflows/test-submission-comment.yaml
@@ -45,4 +45,7 @@ jobs:
           name: comment-flow-selftest
           path: ${{ runner.temp }}/result
           if-no-files-found: error
+          # Re-runs share the workflow run, and v4+ artifacts are immutable, so
+          # without this the upload 409s on every re-run attempt.
+          overwrite: true
           retention-days: 1

--- a/.github/workflows/test-submission-comment.yaml
+++ b/.github/workflows/test-submission-comment.yaml
@@ -1,38 +1,30 @@
 name: Test submission comment flow
 
-# Mirrors what validate-submission's template does — a `pull_request` job that
-# uploads an artifact, and a `workflow_run` job triggered by this workflow's own
-# completion that posts it — but stubs the result instead of running a
-# validation. The posting job calls the same reusable workflow the template
-# calls, so this exercises the real thing rather than a copy of it.
+# Stage 1 of the self-test: stands in for a validation run by uploading a stub
+# result. Stage 2 lives in test-submission-comment-post.yaml, which listens for
+# this workflow completing — a workflow cannot listen to itself, which is the
+# same reason hubs need two files.
 #
-# Two things to know when reading a run of this:
-#
-# - `workflow_run` only fires for workflow files already on the default branch,
-#   so on the pull request that changes this file only the `upload` job runs.
-#   The rest exercises whatever is on main.
-# - Each run is followed by another with every job skipped, because this workflow
-#   triggers on its own completion. GitHub caps `workflow_run` chains at three
-#   levels, so it stops there. That skipped run is the template's behaviour too.
+# On the pull request that changes these files only this half runs: `workflow_run`
+# fires only for workflow files already on the default branch.
 
 on:
   pull_request:
     paths:
       - 'validate-submission/**'
+      - 'validate-submission-comment/**'
       - 'pr-comment/**'
       - 'resolve-pr/**'
+      - '!**/README.md'
       - '.github/workflows/post-validation-comment.yaml'
       - '.github/workflows/test-submission-comment.yaml'
-  workflow_run:
-    workflows: ["Test submission comment flow"]
-    types: [completed]
+      - '.github/workflows/test-submission-comment-post.yaml'
 
 permissions:
   contents: read
 
 jobs:
   upload:
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-22.04
     steps:
       - name: Stand in for a validation summary
@@ -54,52 +46,3 @@ jobs:
           path: ${{ runner.temp }}/result
           if-no-files-found: error
           retention-days: 1
-
-  comment:
-    if: github.event_name == 'workflow_run'
-    uses: ./.github/workflows/post-validation-comment.yaml
-    permissions:
-      contents: read
-      actions: read
-      pull-requests: write
-    with:
-      artifact_name: comment-flow-selftest
-      header: ci-comment-flow
-
-  verify:
-    if: github.event_name == 'workflow_run'
-    needs: comment
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - id: pr
-        uses: hubverse-org/hubverse-actions/resolve-pr@main
-
-      - name: Assert it landed on the right pull request, then clean up
-        if: steps.pr.outputs.number != ''
-        uses: actions/github-script@v7
-        env:
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-        with:
-          script: |
-            const issue_number = Number(process.env.PR_NUMBER);
-            const marker = `<!-- hubverse-comment:ci-comment-flow:${process.env.HEAD_SHA} -->`;
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              ...context.repo,
-              issue_number,
-              per_page: 100,
-            });
-            const mine = comments.filter((c) => c.body && c.body.includes(marker));
-            if (mine.length !== 1) {
-              core.setFailed(`expected exactly 1 comment on PR ${issue_number}, found ${mine.length}`);
-              return;
-            }
-            if (!mine[0].body.includes('comment-flow self-test')) {
-              core.setFailed('the posted comment does not carry the stub summary');
-              return;
-            }
-            await github.rest.issues.deleteComment({ ...context.repo, comment_id: mine[0].id });
-            core.info(`comment flow self-test passed on PR ${issue_number}; test comment removed.`);

--- a/.github/workflows/test-validate-submission.yaml
+++ b/.github/workflows/test-validate-submission.yaml
@@ -14,6 +14,7 @@ on:
   pull_request:
     paths:
       - 'validate-submission/**'
+      - '!**/README.md'
       - '.github/workflows/test-validate-submission.yaml'
 
 permissions:
@@ -22,8 +23,8 @@ permissions:
 
 jobs:
   # The rendering on its own, over the validation objects hubValidations bundles
-  # as test hubs. No hub checkout, no token, and it covers the shapes the fixture
-  # PRs above cannot produce, such as a hub whose config fails to load.
+  # as test hubs. No hub checkout and no token, so it covers rendering the fixture
+  # PRs cannot reach, such as oversized output and a run that never got started.
   summary:
     runs-on: ubuntu-22.04
     steps:
@@ -42,8 +43,9 @@ jobs:
         env:
           GITHUB_PAT: ${{ github.token }}
         with:
-          # Matched to the composite action's list so both restore from the same
-          # setup-r-dependencies cache entry, which is keyed on the resolved set.
+          # Matched to the composite action's list, so that once a branch has run
+          # once these jobs share one setup-r-dependencies cache entry rather than
+          # building two. The key is the resolved package set.
           packages: |
             any::hubValidations
             any::sessioninfo

--- a/.github/workflows/test-validate-submission.yaml
+++ b/.github/workflows/test-validate-submission.yaml
@@ -2,7 +2,12 @@ name: Test validate-submission action
 
 # Exercises the validate-submission composite action (referenced locally) against
 # the standing fixture PRs in hubverse-org/ci-testhub-simple, asserting each
-# produces its expected pass/fail outcome.
+# produces its expected pass/fail outcome and the matching pull request summary.
+# A separate job covers the summary rendering on its own, without a hub.
+#
+# What no job here reaches is the posting half: the artifact handoff and the
+# workflow_run comment only run against a hub that has the template installed on
+# its default branch, with the submission arriving from a fork.
 
 on:
   workflow_dispatch:
@@ -16,6 +21,36 @@ permissions:
   pull-requests: read
 
 jobs:
+  # The rendering on its own, over the validation objects hubValidations bundles
+  # as test hubs. No hub checkout, no token, and it covers the shapes the fixture
+  # PRs above cannot produce, such as a hub whose config fails to load.
+  summary:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          install-r: false
+          use-public-rspm: true
+          extra-repositories: 'https://hubverse-org.r-universe.dev'
+
+      - name: Update apt
+        run: sudo apt-get update
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        env:
+          GITHUB_PAT: ${{ github.token }}
+        with:
+          # Matched to the composite action's list so both restore from the same
+          # setup-r-dependencies cache entry, which is keyed on the resolved set.
+          packages: |
+            any::hubValidations
+            any::sessioninfo
+
+      - name: Run the summary tests
+        run: Rscript validate-submission/tests/test-summary.R
+
   test:
     runs-on: ubuntu-22.04
     strategy:
@@ -49,6 +84,8 @@ jobs:
           # skip the only wall-clock-relative check so the assertion tests the
           # submission content, not the current date.
           skip_submit_window_check: true
+          summary: true
+          artifact_name: fixture-pr-${{ matrix.pr }}
 
       - name: Assert outcome is ${{ matrix.expect }}
         run: |
@@ -57,3 +94,27 @@ jobs:
             exit 1
           fi
           echo "PR ${{ matrix.pr }}: outcome '${{ steps.validate.outcome }}' as expected"
+
+      - name: Assert the pull request summary matches
+        env:
+          # Taken from the action's output, so the test cannot drift from where
+          # the action actually writes.
+          SUMMARY: ${{ steps.validate.outputs.summary-path }}
+          EXPECT: ${{ matrix.expect }}
+          PR: ${{ matrix.pr }}
+        run: |
+          if [ ! -s "$SUMMARY" ]; then
+            echo "::error::PR $PR: no summary written to $SUMMARY"
+            exit 1
+          fi
+          echo "PR $PR summary:"
+          cat "$SUMMARY"
+          if [ "$EXPECT" = success ]; then
+            marker=':white_check_mark:'
+          else
+            marker=':x:'
+          fi
+          if ! grep -qF "$marker" "$SUMMARY"; then
+            echo "::error::PR $PR: summary does not carry $marker"
+            exit 1
+          fi

--- a/pr-comment/README.md
+++ b/pr-comment/README.md
@@ -82,6 +82,11 @@ artifact instead of the event context.
   HTML comment marker used to find the comment again. Anything else fails the
   step. `revision` is checked the same way, allowing `.` as well, since it goes
   into the marker too.
+- Only comments posted by a **bot** are ever adopted and updated. The marker is
+  predictable, so without that check someone could post a comment carrying it and
+  have the next run edit theirs instead. This means `token` must belong to a bot
+  or app identity; a personal access token posts a fresh comment every time
+  rather than updating its own.
 - Create-or-update is not atomic. Two runs with the same `header` racing on one
   PR can each create a comment, so callers that may fire concurrently should
   serialise with a workflow [`concurrency`](https://docs.github.com/actions/using-jobs/using-concurrency)

--- a/pr-comment/README.md
+++ b/pr-comment/README.md
@@ -82,11 +82,12 @@ artifact instead of the event context.
   HTML comment marker used to find the comment again. Anything else fails the
   step. `revision` is checked the same way, allowing `.` as well, since it goes
   into the marker too.
-- Only comments posted by a **bot** are ever adopted and updated. The marker is
-  predictable, so without that check someone could post a comment carrying it and
-  have the next run edit theirs instead. This means `token` must belong to a bot
-  or app identity; a personal access token posts a fresh comment every time
-  rather than updating its own.
+- A comment is only adopted if a **bot** posted it *and* the marker is the first
+  thing in it, which is where this action puts it. The marker is predictable, so
+  without both checks someone could post a comment carrying it, or bury one
+  revision's marker inside another's, and have the next run edit the wrong
+  comment. This means `token` must belong to a bot or app identity; a personal
+  access token posts a fresh comment every time rather than updating its own.
 - Create-or-update is not atomic. Two runs with the same `header` racing on one
   PR can each create a comment, so callers that may fire concurrently should
   serialise with a workflow [`concurrency`](https://docs.github.com/actions/using-jobs/using-concurrency)
@@ -103,7 +104,8 @@ context with a write token.
 The recommended pattern is a two-stage
 [`workflow_run`](https://docs.github.com/actions/using-workflows/events-that-trigger-workflows#workflow_run)
 split: the `pull_request` workflow does the read-only work and uploads its result
-(plus the PR number) as an artifact; a `workflow_run` workflow downloads the
-artifact and calls this action to post. Avoid `pull_request_target` for anything
-that checks out or acts on PR content — it exposes the write token to
-submitter-controlled code.
+as an artifact; a `workflow_run` workflow downloads it and calls this action to
+post. Work out which pull request to post to from the trigger — that is what
+[`resolve-pr`](../resolve-pr) is for — and never from the artifact, which a fork
+controls. Avoid `pull_request_target` for anything that checks out or acts on
+pull request content: it exposes the write token to submitter-controlled code.

--- a/pr-comment/README.md
+++ b/pr-comment/README.md
@@ -3,7 +3,8 @@
 Creates or updates a **single** pull request comment identified by a marker key.
 Each distinct `header` keeps its own sticky comment on a PR, so re-running a
 workflow updates its comment in place and independent workflows never clobber
-each other's.
+each other's. Used by the [submission validation
+flow](../validate-submission/README.md#how-it-works).
 
 It wraps [`actions/github-script`](https://github.com/actions/github-script) —
 no external dependencies — and embeds a hidden marker

--- a/pr-comment/README.md
+++ b/pr-comment/README.md
@@ -56,6 +56,12 @@ the revision changes — which notifies — while a re-run on the **same** revis
 edits that revision's comment in place. Earlier revisions' comments are left
 untouched, so the PR accumulates a history of results across commits.
 
+Because those comments share a heading, each one gains a footer saying which
+revision it is for (`Results for commit \`a1b2c3d\``, with 40-character SHAs
+abbreviated). Timeline position usually implies it, but not when pushes land
+faster than runs finish, when GitHub groups several commits into one entry, or
+when the comment is read from a notification.
+
 ```yaml
 - uses: hubverse-org/hubverse-actions/pr-comment@main
   with:
@@ -74,7 +80,8 @@ artifact instead of the event context.
 
 - `header` must be a slug of letters, digits, `-` or `_`; it is embedded in an
   HTML comment marker used to find the comment again. Anything else fails the
-  step.
+  step. `revision` is checked the same way, allowing `.` as well, since it goes
+  into the marker too.
 - Create-or-update is not atomic. Two runs with the same `header` racing on one
   PR can each create a comment, so callers that may fire concurrently should
   serialise with a workflow [`concurrency`](https://docs.github.com/actions/using-jobs/using-concurrency)

--- a/pr-comment/action.yaml
+++ b/pr-comment/action.yaml
@@ -105,13 +105,14 @@ runs:
             issue_number,
             per_page: 100,
           });
-          // Only ever adopt a comment posted by a bot. The marker is predictable
-          // — the header is documented and the revision is the submitter's own
-          // commit — so a submitter could otherwise plant a comment carrying it
-          // and have the next run edit *their* comment, putting the result under
-          // their authorship for them to rewrite afterwards.
+          // Only ever adopt a comment posted by a bot, and only one whose marker
+          // is where this action puts it. The marker is predictable — the header
+          // is documented and the revision is the submitter's own commit — so a
+          // submitter could otherwise plant one and have the next run edit their
+          // comment, or bury another revision's marker in a body they control
+          // and have that revision's comment adopted instead.
           const existing = comments.find(
-            (c) => c.user && c.user.type === 'Bot' && c.body && c.body.includes(marker)
+            (c) => c.user && c.user.type === 'Bot' && c.body && c.body.startsWith(marker)
           );
 
           let id;

--- a/pr-comment/action.yaml
+++ b/pr-comment/action.yaml
@@ -85,10 +85,13 @@ runs:
           // revision under identical headings. Say which one this is, since the
           // marker that distinguishes them is invisible. Commit SHAs are
           // abbreviated the way GitHub abbreviates them.
-          const label = /^[0-9a-f]{40}$/i.test(revision)
-            ? `commit \`${revision.slice(0, 7)}\``
-            : `revision \`${revision}\``;
-          const footer = revision ? `\n\n---\n<sub>Results for ${label}</sub>` : '';
+          let footer = '';
+          if (revision) {
+            const label = /^[0-9a-f]{40}$/i.test(revision)
+              ? `commit \`${revision.slice(0, 7)}\``
+              : `revision \`${revision}\``;
+            footer = `\n\n---\n<sub>Results for ${label}</sub>`;
+          }
           const body = `${marker}\n${raw}${footer}`;
 
           const issue_number = Number(process.env.PR);
@@ -102,7 +105,14 @@ runs:
             issue_number,
             per_page: 100,
           });
-          const existing = comments.find((c) => c.body && c.body.includes(marker));
+          // Only ever adopt a comment posted by a bot. The marker is predictable
+          // — the header is documented and the revision is the submitter's own
+          // commit — so a submitter could otherwise plant a comment carrying it
+          // and have the next run edit *their* comment, putting the result under
+          // their authorship for them to rewrite afterwards.
+          const existing = comments.find(
+            (c) => c.user && c.user.type === 'Bot' && c.body && c.body.includes(marker)
+          );
 
           let id;
           if (existing) {

--- a/pr-comment/action.yaml
+++ b/pr-comment/action.yaml
@@ -58,6 +58,13 @@ runs:
             core.setFailed(`pr-comment: \`header\` must be a slug of letters, digits, \`-\` or \`_\`; got "${header}".`);
             return;
           }
+          // The revision goes into the marker and into the visible footer, so it
+          // has to be free of anything that could close the HTML comment or the
+          // code span.
+          if (revision && !/^[A-Za-z0-9._-]+$/.test(revision)) {
+            core.setFailed(`pr-comment: \`revision\` must be letters, digits, \`.\`, \`-\` or \`_\`; got "${revision}".`);
+            return;
+          }
           // Fold the revision into the marker: a new revision yields a new marker,
           // so no existing comment matches and a fresh comment is posted, leaving
           // earlier revisions' comments in place. Same revision (or none) matches
@@ -74,7 +81,15 @@ runs:
             core.setFailed('pr-comment: empty body (set `body` or `body_path`).');
             return;
           }
-          const body = `${marker}\n${raw}`;
+          // With a revision set, a pull request accumulates one comment per
+          // revision under identical headings. Say which one this is, since the
+          // marker that distinguishes them is invisible. Commit SHAs are
+          // abbreviated the way GitHub abbreviates them.
+          const label = /^[0-9a-f]{40}$/i.test(revision)
+            ? `commit \`${revision.slice(0, 7)}\``
+            : `revision \`${revision}\``;
+          const footer = revision ? `\n\n---\n<sub>Results for ${label}</sub>` : '';
+          const body = `${marker}\n${raw}${footer}`;
 
           const issue_number = Number(process.env.PR);
           if (!Number.isInteger(issue_number) || issue_number <= 0) {

--- a/resolve-pr/README.md
+++ b/resolve-pr/README.md
@@ -49,12 +49,12 @@ Every input defaults to the right field of `github.event.workflow_run`, so a
 |---|---|
 | `number` | The pull request number, or **empty** if no open pull request matches. |
 
-An empty `number` is not an error. The pull request may have been closed or
-merged between the triggering run finishing and this one starting, or the branch
-may back several open pull requests with none at this commit — the action will
-not guess between them. Gate later steps on `steps.<id>.outputs.number != ''`
-rather than letting them fail.
+An empty `number` is not an error, so gate later steps on
+`steps.<id>.outputs.number != ''` rather than letting them fail. It means one of:
+the pull request was closed or merged while the first run was finishing; the fork
+it came from was deleted; or the branch backs several open pull requests and none
+is at this commit, in which case the action will not guess between them.
 
-Called outside a `workflow_run` job, where the defaults resolve to nothing, it
-fails rather than returning an arbitrary pull request. Pass the inputs
+It fails only when given nothing at all to work with, which happens outside a
+`workflow_run` job, where the defaults resolve to nothing. Pass the inputs
 explicitly if you need it elsewhere.

--- a/resolve-pr/README.md
+++ b/resolve-pr/README.md
@@ -1,0 +1,55 @@
+# resolve-pr
+
+Finds the pull request behind a completed workflow run, for a `workflow_run` job
+that needs to act on that run's result.
+
+```yaml
+- id: pr
+  uses: hubverse-org/hubverse-actions/resolve-pr@main
+
+- if: steps.pr.outputs.number != ''
+  uses: hubverse-org/hubverse-actions/pr-comment@main
+  with:
+    pr: ${{ steps.pr.outputs.number }}
+    header: my-workflow
+    body_path: result.md
+```
+
+## Why not read the number from the run
+
+A `workflow_run` job runs in the base repository's context with a write token,
+while the run that triggered it may have come from a fork — and a fork pull
+request runs **its own copy** of the triggering workflow, so everything that run
+produced is submitter-controlled. Taking the pull request number from an artifact
+would let a fork have the repository act on any pull request it named.
+
+Everything this action reads comes from the `workflow_run` payload, which the
+submitter cannot forge.
+
+`github.event.workflow_run.pull_requests` is not usable for this: it is empty for
+fork pull requests, which is the case that matters. The lookup goes by head
+repository and branch instead, disambiguated by head commit when a branch has
+been reused across pull requests.
+
+## Inputs
+
+Every input defaults to the right field of `github.event.workflow_run`, so a
+`workflow_run` job needs none of them.
+
+| Input | Default | Description |
+|---|---|---|
+| `head_repository` | run's head repo | Repository the head branch lives in, as `owner/name`. |
+| `head_owner` | run's head repo owner | Owner of that repository. |
+| `head_branch` | run's head branch | Head branch of the run. |
+| `head_sha` | run's head commit | Used to pick between pull requests sharing a branch name. |
+| `token` | `${{ github.token }}` | Token used to look the pull request up. |
+
+## Outputs
+
+| Output | Description |
+|---|---|
+| `number` | The pull request number, or **empty** if no open pull request matches. |
+
+An empty `number` is not an error: the pull request may have been closed or
+merged between the triggering run finishing and this one starting. Gate later
+steps on `steps.<id>.outputs.number != ''` rather than letting them fail.

--- a/resolve-pr/README.md
+++ b/resolve-pr/README.md
@@ -1,7 +1,8 @@
 # resolve-pr
 
 Finds the pull request behind a completed workflow run, for a `workflow_run` job
-that needs to act on that run's result.
+that needs to act on that run's result. Used by the [submission validation
+flow](../validate-submission/README.md#how-it-works).
 
 ```yaml
 - id: pr

--- a/resolve-pr/README.md
+++ b/resolve-pr/README.md
@@ -38,7 +38,6 @@ Every input defaults to the right field of `github.event.workflow_run`, so a
 
 | Input | Default | Description |
 |---|---|---|
-| `head_repository` | run's head repo | Repository the head branch lives in, as `owner/name`. |
 | `head_owner` | run's head repo owner | Owner of that repository. |
 | `head_branch` | run's head branch | Head branch of the run. |
 | `head_sha` | run's head commit | Used to pick between pull requests sharing a branch name. |
@@ -50,6 +49,12 @@ Every input defaults to the right field of `github.event.workflow_run`, so a
 |---|---|
 | `number` | The pull request number, or **empty** if no open pull request matches. |
 
-An empty `number` is not an error: the pull request may have been closed or
-merged between the triggering run finishing and this one starting. Gate later
-steps on `steps.<id>.outputs.number != ''` rather than letting them fail.
+An empty `number` is not an error. The pull request may have been closed or
+merged between the triggering run finishing and this one starting, or the branch
+may back several open pull requests with none at this commit — the action will
+not guess between them. Gate later steps on `steps.<id>.outputs.number != ''`
+rather than letting them fail.
+
+Called outside a `workflow_run` job, where the defaults resolve to nothing, it
+fails rather than returning an arbitrary pull request. Pass the inputs
+explicitly if you need it elsewhere.

--- a/resolve-pr/action.yaml
+++ b/resolve-pr/action.yaml
@@ -1,0 +1,59 @@
+name: "Resolve the pull request behind a workflow_run"
+description: >-
+  Find the pull request a completed workflow run came from, using only the
+  trigger payload, so a job acting on that run's artifacts cannot be pointed at
+  another pull request.
+author: "hubverse"
+
+inputs:
+  head_repository:
+    description: "Repository the run's head branch lives in, as owner/name."
+    default: ${{ github.event.workflow_run.head_repository.full_name }}
+  head_owner:
+    description: "Owner of that repository."
+    default: ${{ github.event.workflow_run.head_repository.owner.login }}
+  head_branch:
+    description: "Head branch of the run."
+    default: ${{ github.event.workflow_run.head_branch }}
+  head_sha:
+    description: "Head commit of the run, used to pick between branches reused across pull requests."
+    default: ${{ github.event.workflow_run.head_sha }}
+  token:
+    description: "Token used to look the pull request up."
+    default: ${{ github.token }}
+
+outputs:
+  number:
+    description: >-
+      The pull request number, or empty if there is no longer an open pull
+      request for that branch. Gate later steps on this being non-empty.
+    value: ${{ steps.resolve.outputs.number }}
+
+runs:
+  using: composite
+  steps:
+    - id: resolve
+      uses: actions/github-script@v7
+      env:
+        HEAD_REPO: ${{ inputs.head_repository }}
+        HEAD_OWNER: ${{ inputs.head_owner }}
+        HEAD_BRANCH: ${{ inputs.head_branch }}
+        HEAD_SHA: ${{ inputs.head_sha }}
+      with:
+        github-token: ${{ inputs.token }}
+        script: |
+          const prs = await github.paginate(github.rest.pulls.list, {
+            ...context.repo,
+            state: 'open',
+            head: `${process.env.HEAD_OWNER}:${process.env.HEAD_BRANCH}`,
+            per_page: 100,
+          });
+          const pr = prs.find((p) => p.head.sha === process.env.HEAD_SHA) || prs[0];
+          if (!pr) {
+            // Closed or merged between the run finishing and this running.
+            // Nothing to act on, and nothing wrong either.
+            core.info(`No open pull request for ${process.env.HEAD_REPO}:${process.env.HEAD_BRANCH}.`);
+            core.setOutput('number', '');
+            return;
+          }
+          core.setOutput('number', pr.number);

--- a/resolve-pr/action.yaml
+++ b/resolve-pr/action.yaml
@@ -6,11 +6,8 @@ description: >-
 author: "hubverse"
 
 inputs:
-  head_repository:
-    description: "Repository the run's head branch lives in, as owner/name."
-    default: ${{ github.event.workflow_run.head_repository.full_name }}
   head_owner:
-    description: "Owner of that repository."
+    description: "Owner of the repository the run's head branch lives in."
     default: ${{ github.event.workflow_run.head_repository.owner.login }}
   head_branch:
     description: "Head branch of the run."
@@ -35,24 +32,40 @@ runs:
     - id: resolve
       uses: actions/github-script@v7
       env:
-        HEAD_REPO: ${{ inputs.head_repository }}
         HEAD_OWNER: ${{ inputs.head_owner }}
         HEAD_BRANCH: ${{ inputs.head_branch }}
         HEAD_SHA: ${{ inputs.head_sha }}
       with:
         github-token: ${{ inputs.token }}
         script: |
+          const owner = process.env.HEAD_OWNER;
+          const branch = process.env.HEAD_BRANCH;
+          // Empty outside a workflow_run context, where the defaults resolve to
+          // nothing. Without this the filter becomes `head: ':'` and whatever
+          // comes back would be an arbitrary pull request.
+          if (!owner || !branch) {
+            core.setFailed('resolve-pr: no head repository or branch. Outside a `workflow_run` job, pass them explicitly.');
+            return;
+          }
+
           const prs = await github.paginate(github.rest.pulls.list, {
             ...context.repo,
             state: 'open',
-            head: `${process.env.HEAD_OWNER}:${process.env.HEAD_BRANCH}`,
+            head: `${owner}:${branch}`,
             per_page: 100,
           });
-          const pr = prs.find((p) => p.head.sha === process.env.HEAD_SHA) || prs[0];
+
+          // A branch can back more than one open pull request when they target
+          // different bases. Prefer the one at this commit; fall back to the only
+          // candidate when the branch has moved on since the run started, but
+          // never guess between several.
+          const pr = prs.find((p) => p.head.sha === process.env.HEAD_SHA) ||
+            (prs.length === 1 ? prs[0] : undefined);
           if (!pr) {
-            // Closed or merged between the run finishing and this running.
-            // Nothing to act on, and nothing wrong either.
-            core.info(`No open pull request for ${process.env.HEAD_REPO}:${process.env.HEAD_BRANCH}.`);
+            const why = prs.length > 1
+              ? `${prs.length} open pull requests share that branch and none is at ${process.env.HEAD_SHA}`
+              : 'it is closed or merged';
+            core.info(`No pull request resolved for ${owner}:${branch} — ${why}.`);
             core.setOutput('number', '');
             return;
           }

--- a/resolve-pr/action.yaml
+++ b/resolve-pr/action.yaml
@@ -40,11 +40,20 @@ runs:
         script: |
           const owner = process.env.HEAD_OWNER;
           const branch = process.env.HEAD_BRANCH;
-          // Empty outside a workflow_run context, where the defaults resolve to
-          // nothing. Without this the filter becomes `head: ':'` and whatever
-          // comes back would be an arbitrary pull request.
-          if (!owner || !branch) {
+          // Nothing at all means this ran outside a workflow_run job, where the
+          // defaults resolve to nothing. That is a wiring mistake, and without
+          // the guard the filter becomes `head: ':'` and returns an arbitrary
+          // pull request.
+          if (!owner && !branch) {
             core.setFailed('resolve-pr: no head repository or branch. Outside a `workflow_run` job, pass them explicitly.');
+            return;
+          }
+          // Half a reference means the fork was deleted while the pull request
+          // was open. Nothing to act on, and nothing wrong — but never build a
+          // half-empty `head:` filter out of it.
+          if (!owner || !branch) {
+            core.info(`Incomplete head reference (${owner || '?'}:${branch || '?'}); the fork was probably deleted.`);
+            core.setOutput('number', '');
             return;
           }
 

--- a/validate-submission-comment/README.md
+++ b/validate-submission-comment/README.md
@@ -24,6 +24,9 @@ That second run has to be a **separate workflow file**: GitHub rejects a workflo
 that names itself as its own trigger, with `Workflow '...' cannot listen to
 itself`.
 
+Like the validation workflow, it does not run on forks of your hub — a submitter
+should see results on their pull request here, not in their own copy.
+
 ## Keeping the two in step
 
 The trigger matches the validation workflow by name:

--- a/validate-submission-comment/README.md
+++ b/validate-submission-comment/README.md
@@ -1,0 +1,47 @@
+# validate-submission-comment
+
+Posts the result of [`validate-submission`](../validate-submission) as a comment
+on the pull request it came from.
+
+This is the second of the two workflows a hub needs. Add both:
+
+```r
+hubCI::use_hub_github_action("validate-submission")
+hubCI::use_hub_github_action("validate-submission-comment")
+```
+
+Without this one, validation still runs and still fails the check — the result
+just never reaches the pull request.
+
+## Why it is a separate file
+
+Most submissions come from forks, and GitHub gives a fork's pull request
+read-only access, so the workflow running the checks cannot comment on its own
+result. The result has to be posted by a second run, triggered by the first
+finishing, which happens in the hub's own context.
+
+That second run has to be a **separate workflow file**: GitHub rejects a workflow
+that names itself as its own trigger, with `Workflow '...' cannot listen to
+itself`.
+
+## Keeping the two in step
+
+The trigger matches the validation workflow by name:
+
+```yaml
+on:
+  workflow_run:
+    workflows: ["Hub Submission Validation (R)"]
+```
+
+If you rename the validation workflow, change this to match. Nothing reports an
+error when it stops matching — results simply stop being posted.
+
+## What is in it
+
+Almost nothing. The steps live in a
+[shared workflow](../.github/workflows/post-validation-comment.yaml) in
+hubverse-actions, so the artifact name, the action versions and the concurrency
+key stay fixable there rather than frozen in your copy. See
+[validate-submission's README](../validate-submission#what-a-submitter-sees) for
+what gets posted and how the two stages fit together.

--- a/validate-submission-comment/validate-submission-comment.yaml
+++ b/validate-submission-comment/validate-submission-comment.yaml
@@ -1,0 +1,31 @@
+name: Post Submission Validation Result
+
+# Companion to Hub Submission Validation (R). That workflow runs the checks and
+# saves the result, but a `pull_request` workflow triggered from a fork gets a
+# read-only GITHUB_TOKEN, so it cannot comment. This one runs once it finishes,
+# in the hub's own context, and posts what it saved.
+#
+# A workflow cannot listen to itself, which is why this is a second file rather
+# than another job in the first.
+#
+# `workflows:` below must match the validation workflow's `name:`. If you rename
+# that workflow, rename it here too, or results will quietly stop being posted.
+#
+# The steps live in hubverse-actions rather than here, so that fixes to them
+# reach you without you having to add a new copy of this file.
+
+on:
+  workflow_run:
+    workflows: ["Hub Submission Validation (R)"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  comment:
+    uses: hubverse-org/hubverse-actions/.github/workflows/post-validation-comment.yaml@main
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write

--- a/validate-submission-comment/validate-submission-comment.yaml
+++ b/validate-submission-comment/validate-submission-comment.yaml
@@ -24,6 +24,11 @@ permissions:
 
 jobs:
   comment:
+    # Skipped on forks of the hub, matching the validation workflow. Stated here
+    # rather than relying on that workflow being skipped, because a run whose
+    # only job was skipped does not reliably report a conclusion this one treats
+    # as "nothing to do".
+    if: github.event.repository.fork != true
     uses: hubverse-org/hubverse-actions/.github/workflows/post-validation-comment.yaml@main
     permissions:
       contents: read

--- a/validate-submission/README.md
+++ b/validate-submission/README.md
@@ -47,9 +47,30 @@ default to the workflow context, so the turnkey case needs no inputs at all.
 | `derived_task_ids` | *(empty)* | Comma-separated task IDs derived from other task IDs. |
 | `verbose` | `true` | Print the result of every check before the summary. |
 | `show_warnings` | `false` | Print check-level warnings inline. |
+| `summary_path` | *(empty)* | Path to write a markdown summary of the check results to. See [Posting the result to the pull request](#posting-the-result-to-the-pull-request). |
 | `extra_packages` | *(empty)* | Extra R packages to install (`setup-r-dependencies` syntax). |
 | `extra_repositories` | hubverse r-universe | Extra R package repositories. |
 | `github_token` | `${{ github.token }}` | Token used to read PR files via the GitHub API. |
+
+## Posting the result to the pull request
+
+Set `summary_path` and the action writes a markdown summary of the check results
+there, ready to post as a pull request comment. The template workflow uploads it
+as an artifact, and the companion
+[`validate-submission-comment`](../validate-submission-comment) workflow posts it.
+Both templates are needed:
+
+```r
+hubCI::use_hub_github_action("validate-submission")
+hubCI::use_hub_github_action("validate-submission-comment")
+```
+
+The split exists because a `pull_request` workflow triggered from a fork gets a
+read-only token and cannot comment. See the companion README for the detail.
+
+Setting `summary_path` also routes the check results through the summary file
+before they reach the workflow log, which drops the colour they would otherwise
+be printed in. The log content is unchanged.
 
 For more on configuring validation checks, see the `hubValidations` vignette on
 [Validating Pull Requests on GitHub](https://hubverse-org.github.io/hubValidations/articles/validate-pr.html).

--- a/validate-submission/README.md
+++ b/validate-submission/README.md
@@ -1,25 +1,158 @@
 # validate-submission
 
-Validates the model-output and model-metadata files in a hub pull request with
-[`hubValidations::validate_pr()`](https://hubverse-org.github.io/hubValidations/articles/validate-pr.html).
+Checks a submission as soon as it arrives and tells the submitter what is wrong,
+without them having to go hunting through logs.
 
-It installs `hubValidations` from the
-[hubverse R universe](https://hubverse-org.r-universe.dev/packages) along with the
-required system dependencies, then runs the submission checks and reports the
-result in the workflow log, failing the job if any check does not pass.
+When someone opens a pull request adding or changing files under `model-output/`
+or `model-metadata/`, those files are run through
+[`hubValidations`](https://hubverse-org.github.io/hubValidations/articles/validate-pr.html).
+The result is posted as a comment on the pull request, and the pull request's
+check fails if anything did not pass.
 
-This directory provides two things:
+Everything in this directory serves that one job:
 
-- **A template workflow** (`validate-submission.yaml`) that most hubs use as-is.
-  It is scaffolded into a hub with `hubCI::use_hub_github_action("validate-submission")`
-  and triggers on pull requests that add or modify files under `model-output/` or
-  `model-metadata/`.
-- **A composite action** (`action.yaml`) holding the logic, which the template
-  calls and which advanced hubs can drop into their own workflows.
+| File | What it does |
+|---|---|
+| `validate-submission.yaml` | The workflow you add to your hub — the file GitHub runs. Most hubs use it exactly as it comes. |
+| `action.yaml` | The action it calls — a reusable piece of work: sets up R, runs the checks, writes up the result. |
+| `validate.R`, `summary.R` | The R behind it — running the checks, and turning their output into a comment. |
+| `tests/` | Checks on the comment formatting, run in this repository's own CI. |
 
-## Using the action directly
+## Setting it up
 
-The action assumes the repository is already checked out.
+From the root of your hub:
+
+```r
+hubCI::use_hub_github_action("validate-submission")
+```
+
+That adds `.github/workflows/validate-submission.yaml`. There is nothing else to
+do — commenting is on by default, and the common case needs no settings at all.
+
+## What a submitter sees
+
+A comment giving a pass or fail line and the check results, shown in full when
+something failed and tucked behind a toggle when everything passed.
+
+Each new commit gets its own comment, which notifies the submitter that the
+result has changed. Re-running the same commit edits its existing comment instead
+of adding another, so the pull request keeps a history of results without filling
+up with duplicates.
+
+If the checks never get to run at all — a bad hub config, an outage while
+installing R packages — the submitter still gets a comment saying so, rather than
+a bare red cross with no explanation.
+
+### How it works
+
+```mermaid
+flowchart TB
+    A["Submission pull request<br/>(usually from a fork)"]
+
+    subgraph s1["Stage 1 · runs on the pull request · read-only"]
+        B["validate job"]
+        C["validate-submission action<br/>runs the checks, writes up the result"]
+        D[("result file,<br/>saved to the run")]
+        B --> C --> D
+    end
+
+    subgraph s2["Stage 2 · runs as your hub · allowed to comment"]
+        E["comment job"]
+        F["post-validation-comment<br/>shared workflow"]
+        G["resolve-pr<br/>which pull request was this?"]
+        H["pr-comment<br/>post, or update in place"]
+        E --> F --> G --> H
+    end
+
+    A --> B
+    D -. "stage 1 finishes, which starts stage 2;<br/>the file is picked up but not trusted" .-> E
+    H --> I["Result appears on the pull request"]
+```
+
+Most submissions come from forks of your hub, and GitHub deliberately gives a
+fork's pull request **read-only** access — otherwise anyone who opened a pull
+request could make your hub act on their behalf. So the job that runs the checks
+is not allowed to comment on its own result.[^token]
+
+The work is split in two because of that. `validate` runs on the pull request,
+does the checks, and saves the result to the workflow run. `comment` runs once
+that finishes, as your hub rather than as the submitter, and posts it. It only
+ever handles the saved file — it never checks out or runs anything from the pull
+request — so a submission cannot get at the permissions it holds.[^triggers]
+
+The saved file is not trusted either. A submission from a fork runs its own copy
+of the `validate` job, so it controls what ends up in that file. This is why
+Stage 2 works out which pull request to comment on from GitHub's own record of
+what triggered it, rather than from anything Stage 1 produced. Otherwise a
+submission could have your hub post onto someone else's pull request (this is
+what [`resolve-pr`](../resolve-pr) does). What a submitter does still control is
+the wording of the comment on their own pull request, which they could have typed
+by hand anyway.
+
+The `comment` job does not spell its steps out in your hub's copy. It calls a
+[workflow kept here in hubverse-actions](../.github/workflows/post-validation-comment.yaml),
+and that is deliberate. The copy of the workflow file in your hub is yours: once
+you have added it, nothing we change afterwards reaches it. So it holds only the
+parts you might genuinely want to adjust, and the machinery behind them stays on
+our side, where you pick up fixes automatically instead of having to add a fresh
+copy of the file every time something changes.
+
+Two things worth knowing:
+
+- Stage 2 finds Stage 1 **by the workflow's name**. If you rename the workflow,
+  change the `workflows:` list in the same file to match, or results will quietly
+  stop being posted. Nothing reports an error when this happens.
+- Because the workflow starts Stage 2 when it finishes, you will see an extra run
+  in the Actions tab with every job skipped. That is expected, and it goes no
+  further than one.
+
+If the pull request is closed or merged in the gap between the checks finishing
+and the comment being posted, there is nothing to comment on, and the job simply
+stops rather than reporting a failure.
+
+A very large submission can produce more output than GitHub will accept in a
+single comment. When that happens the comment is trimmed to fit, keeping the end,
+where the failures are listed. The workflow log always has the whole thing.
+
+## Customising validation
+
+Most hubs need none of this, but every option
+[`validate_pr()`](https://hubverse-org.github.io/hubValidations/articles/validate-pr.html)
+takes is available as a setting. Add them under `with:` on the
+`validate-submission` step in your workflow file:
+
+```yaml
+- uses: hubverse-org/hubverse-actions/validate-submission@main
+  with:
+    summary: true
+    skip_submit_window_check: true
+```
+
+| Input | Default | Description |
+|---|---|---|
+| `hub_path` | `.` | Path to the hub, relative to the checkout root. |
+| `gh_repo` | workflow repo | Hub repository as `owner/name`. |
+| `pr_number` | triggering PR | Pull request number to validate. |
+| `round_id_col` | *(empty)* | Column holding round IDs, if not configured in `tasks.json`. |
+| `output_type_id_datatype` | `from_config` | Type to convert `output_type_id` to. |
+| `validations_cfg_path` | *(empty)* | Path to a custom validations config file. |
+| `skip_submit_window_check` | `false` | Skip the submission window check. |
+| `file_modification_check` | `error` | How to treat changes to files already submitted. |
+| `allow_submit_window_mods` | `true` | Allow changes to model-output files while their window is open. |
+| `submit_window_ref_date_from` | `file` | Where the submission window reference date comes from. |
+| `derived_task_ids` | *(empty)* | Comma-separated task IDs derived from other task IDs. |
+| `verbose` | `true` | Print the result of every check before the summary. |
+| `show_warnings` | `false` | Print check-level warnings inline. |
+| `summary` | `false`, but `true` in the template | Write up the result and save it for the comment job to post. Turn off to keep results in the workflow log only. |
+| `artifact_name` | `submission-validation-results` | Name the result is saved under. Must match the name the comment job looks for. |
+| `extra_packages` | *(empty)* | Extra R packages to install, for custom checks that need them. |
+| `extra_repositories` | hubverse r-universe | Extra R package repositories. |
+| `github_token` | `${{ github.token }}` | Token used to read the pull request's files. |
+
+## Using the action on its own
+
+If your hub needs a workflow of its own rather than the supplied one, the action
+can be called directly. It assumes the repository is already checked out.
 
 ```yaml
 steps:
@@ -29,48 +162,34 @@ steps:
       skip_submit_window_check: true
 ```
 
-Every `validate_pr()` argument is exposed as an input. `gh_repo` and `pr_number`
-default to the workflow context, so the turnkey case needs no inputs at all.
+It reports one output:
 
-| Input | Default | Description |
-|---|---|---|
-| `hub_path` | `.` | Path to the hub, relative to the checkout root. |
-| `gh_repo` | workflow repo | Hub repository as `owner/name`. |
-| `pr_number` | triggering PR | Pull request number to validate. |
-| `round_id_col` | *(empty)* | Column holding round IDs, if not configured in `tasks.json`. |
-| `output_type_id_datatype` | `from_config` | Type to coerce `output_type_id` to. |
-| `validations_cfg_path` | *(empty)* | Path to a custom validations config file. |
-| `skip_submit_window_check` | `false` | Skip the submission window check. |
-| `file_modification_check` | `error` | How to treat modification/deletion of submitted files. |
-| `allow_submit_window_mods` | `true` | Allow in-window modification/deletion of model-output files. |
-| `submit_window_ref_date_from` | `file` | Where the submission window reference date comes from. |
-| `derived_task_ids` | *(empty)* | Comma-separated task IDs derived from other task IDs. |
-| `verbose` | `true` | Print the result of every check before the summary. |
-| `show_warnings` | `false` | Print check-level warnings inline. |
-| `summary_path` | *(empty)* | Path to write a markdown summary of the check results to. See [Posting the result to the pull request](#posting-the-result-to-the-pull-request). |
-| `extra_packages` | *(empty)* | Extra R packages to install (`setup-r-dependencies` syntax). |
-| `extra_repositories` | hubverse r-universe | Extra R package repositories. |
-| `github_token` | `${{ github.token }}` | Token used to read PR files via the GitHub API. |
+| Output | Description |
+|---|---|
+| `summary-path` | Where the written-up result was saved. Empty unless `summary` is on. |
 
-## Posting the result to the pull request
+For more on configuring the checks themselves, see the `hubValidations` vignette
+on [Validating Pull Requests on GitHub](https://hubverse-org.github.io/hubValidations/articles/validate-pr.html).
 
-Set `summary_path` and the action writes a markdown summary of the check results
-there, ready to post as a pull request comment. The template workflow uploads it
-as an artifact, and the companion
-[`validate-submission-comment`](../validate-submission-comment) workflow posts it.
-Both templates are needed:
+## For maintainers: why the comment half is a workflow
 
-```r
-hubCI::use_hub_github_action("validate-submission")
-hubCI::use_hub_github_action("validate-submission-comment")
-```
+`resolve-pr` and `pr-comment` get their own directories;
+[`post-validation-comment`](../.github/workflows/post-validation-comment.yaml)
+sits in `.github/workflows/` instead. Actions are found by path and can live
+anywhere; workflows are only ever found by scanning `.github/workflows/`, and
+that holds for reusable ones too.
 
-The split exists because a `pull_request` workflow triggered from a fork gets a
-read-only token and cannot comment. See the companion README for the detail.
+It is a workflow rather than an action because only a workflow can carry
+`concurrency:`, `permissions:` and a job-level `if:`. As an action those would
+have to live in the template, which is copied into each hub and frozen there —
+and the concurrency key in particular has already needed changing once.
 
-Setting `summary_path` also routes the check results through the summary file
-before they reach the workflow log, which drops the colour they would otherwise
-be printed in. The log content is unchanged.
+[^token]: In GitHub's own terms: a `pull_request` workflow triggered from a fork
+    gets a read-only `GITHUB_TOKEN`. `pull-requests: write` is downgraded and
+    secrets are withheld, whatever the workflow asks for.
 
-For more on configuring validation checks, see the `hubValidations` vignette on
-[Validating Pull Requests on GitHub](https://hubverse-org.github.io/hubValidations/articles/validate-pr.html).
+[^triggers]: The `comment` job is triggered by
+    [`workflow_run`](https://docs.github.com/actions/using-workflows/events-that-trigger-workflows#workflow_run)
+    on this workflow's own completion, which runs in the base repository's
+    context with a write token. `pull_request_target` is deliberately avoided: it
+    would run submitter-modifiable custom check code with that token.

--- a/validate-submission/README.md
+++ b/validate-submission/README.md
@@ -13,7 +13,7 @@ Everything in this directory serves that one job:
 
 | File | What it does |
 |---|---|
-| `validate-submission.yaml` | The workflow you add to your hub — the file GitHub runs. Most hubs use it exactly as it comes. |
+| `validate-submission.yaml` | The workflow you add to your hub — the file GitHub runs. Most hubs use it exactly as it comes. Its companion, [`validate-submission-comment`](../validate-submission-comment), posts the result. |
 | `action.yaml` | The action it calls — a reusable piece of work: sets up R, runs the checks, writes up the result. |
 | `validate.R`, `summary.R` | The R behind it — running the checks, and turning their output into a comment. |
 | `tests/` | Checks on the comment formatting, run in this repository's own CI. |
@@ -24,10 +24,14 @@ From the root of your hub:
 
 ```r
 hubCI::use_hub_github_action("validate-submission")
+hubCI::use_hub_github_action("validate-submission-comment")
 ```
 
-That adds `.github/workflows/validate-submission.yaml`. There is nothing else to
-do — commenting is on by default, and the common case needs no settings at all.
+Two workflows, because one runs the checks and the other posts the result — see
+[how it works](#how-it-works) for why that has to be split. Commenting is on by
+default and the common case needs no settings at all. Without the second, the
+checks still run and still fail the pull request; the result just never reaches
+the submitter.
 
 ## What a submitter sees
 
@@ -56,7 +60,7 @@ flowchart TB
         B --> C --> D
     end
 
-    subgraph s2["Stage 2 · runs as your hub · allowed to comment"]
+    subgraph s2["Stage 2 · validate-submission-comment · runs as your hub"]
         E["comment job"]
         F["post-validation-comment<br/>shared workflow"]
         G["resolve-pr<br/>which pull request was this?"]
@@ -74,11 +78,15 @@ fork's pull request **read-only** access — otherwise anyone who opened a pull
 request could make your hub act on their behalf. So the job that runs the checks
 is not allowed to comment on its own result.[^token]
 
-The work is split in two because of that. `validate` runs on the pull request,
-does the checks, and saves the result to the workflow run. `comment` runs once
-that finishes, as your hub rather than as the submitter, and posts it. It only
-ever handles the saved file — it never checks out or runs anything from the pull
+The work is split in two because of that. This workflow runs on the pull request,
+does the checks, and saves the result to the workflow run.
+[`validate-submission-comment`](../validate-submission-comment) runs once that
+finishes, as your hub rather than as the submitter, and posts it. It only ever
+handles the saved file — it never checks out or runs anything from the pull
 request — so a submission cannot get at the permissions it holds.[^triggers]
+
+They have to be two separate files: GitHub rejects a workflow that names itself
+as its own trigger, with `Workflow '...' cannot listen to itself`.
 
 The saved file is not trusted either. A submission from a fork runs its own copy
 of the `validate` job, so it controls what ends up in that file. This is why
@@ -97,14 +105,10 @@ parts you might genuinely want to adjust, and the machinery behind them stays on
 our side, where you pick up fixes automatically instead of having to add a fresh
 copy of the file every time something changes.
 
-Two things worth knowing:
-
-- Stage 2 finds Stage 1 **by the workflow's name**. If you rename the workflow,
-  change the `workflows:` list in the same file to match, or results will quietly
-  stop being posted. Nothing reports an error when this happens.
-- Because the workflow starts Stage 2 when it finishes, you will see an extra run
-  in the Actions tab with every job skipped. That is expected, and it goes no
-  further than one.
+Stage 2 finds Stage 1 **by the workflow's name**. If you rename this workflow,
+change the `workflows:` list in `validate-submission-comment.yaml` to match, or
+results will quietly stop being posted. Nothing reports an error when the two
+stop matching.
 
 If the pull request is closed or merged in the gap between the checks finishing
 and the comment being posted, there is nothing to comment on, and the job simply
@@ -143,8 +147,8 @@ takes is available as a setting. Add them under `with:` on the
 | `derived_task_ids` | *(empty)* | Comma-separated task IDs derived from other task IDs. |
 | `verbose` | `true` | Print the result of every check before the summary. |
 | `show_warnings` | `false` | Print check-level warnings inline. |
-| `summary` | `false`, but `true` in the template | Write up the result and save it for the comment job to post. Turn off to keep results in the workflow log only. |
-| `artifact_name` | `submission-validation-results` | Name the result is saved under. Must match the name the comment job looks for. |
+| `summary` | `false`, but `true` in the template | Write up the result and save it for the companion workflow to post. Turn it off to keep results in the workflow log only; the companion workflow then finds nothing to post and stops quietly, so you can leave or delete it. |
+| `artifact_name` | `submission-validation-results` | Name the result is saved under. Coordination between the two workflows rather than a setting to change. |
 | `extra_packages` | *(empty)* | Extra R packages to install, for custom checks that need them. |
 | `extra_repositories` | hubverse r-universe | Extra R package repositories. |
 | `github_token` | `${{ github.token }}` | Token used to read the pull request's files. |

--- a/validate-submission/README.md
+++ b/validate-submission/README.md
@@ -54,7 +54,7 @@ flowchart TB
     A["Submission pull request<br/>(usually from a fork)"]
 
     subgraph s1["Stage 1 · runs on the pull request · read-only"]
-        B["validate job"]
+        B["validation workflow"]
         C["validate-submission action<br/>runs the checks, writes up the result"]
         D[("result file,<br/>saved to the run")]
         B --> C --> D
@@ -89,7 +89,7 @@ They have to be two separate files: GitHub rejects a workflow that names itself
 as its own trigger, with `Workflow '...' cannot listen to itself`.
 
 The saved file is not trusted either. A submission from a fork runs its own copy
-of the `validate` job, so it controls what ends up in that file. This is why
+of Stage 1, so it controls what ends up in that file. This is why
 Stage 2 works out which pull request to comment on from GitHub's own record of
 what triggered it, rather than from anything Stage 1 produced. Otherwise a
 submission could have your hub post onto someone else's pull request (this is
@@ -104,6 +104,13 @@ you have added it, nothing we change afterwards reaches it. So it holds only the
 parts you might genuinely want to adjust, and the machinery behind them stays on
 our side, where you pick up fixes automatically instead of having to add a fresh
 copy of the file every time something changes.
+
+Neither workflow runs on a **fork of your hub**. A submitter working in their own
+fork would otherwise see checks run, and sometimes fail, against their copy —
+which tells them nothing, since the validation that decides whether their
+submission is accepted is the one that runs on their pull request here. Delete
+the `if:` line from either workflow if your hub wants forks to validate
+themselves.
 
 Stage 2 finds Stage 1 **by the workflow's name**. If you rename this workflow,
 change the `workflows:` list in `validate-submission-comment.yaml` to match, or

--- a/validate-submission/action.yaml
+++ b/validate-submission/action.yaml
@@ -61,8 +61,9 @@ inputs:
     default: "false"
   artifact_name:
     description: >-
-      Name of the artifact the summary is uploaded as. Must match the
-      `artifact_name` the companion comment workflow reads.
+      Name of the artifact the summary is uploaded as. Coordination between this
+      action and the workflow that posts the result, not a hub setting — change
+      it only if you also pass a matching `artifact_name` to that workflow.
     default: "submission-validation-results"
   # environment / setup
   extra_packages:
@@ -144,8 +145,11 @@ runs:
     # Validation writes no summary if it never got as far as running — a failed
     # apt update, an r-universe outage. Without this the artifact would carry
     # nothing to post and the submitter would be back to a bare red cross.
+    #
+    # Deliberately duplicates the shape summary.R produces: R may never have
+    # installed, so this cannot go through render_exec_error().
     - name: Fall back to a summary if validation could not run
-      if: always() && inputs.summary == 'true'
+      if: ${{ !cancelled() && steps.paths.outputs.summary != '' }}
       shell: bash
       env:
         SUMMARY: ${{ steps.paths.outputs.summary }}
@@ -153,7 +157,6 @@ runs:
         if [ -s "$SUMMARY" ]; then
           exit 0
         fi
-        mkdir -p "$(dirname "$SUMMARY")"
         cat > "$SUMMARY" <<'EOF'
         ## Submission validation
 
@@ -161,7 +164,7 @@ runs:
         EOF
 
     - name: Upload the summary
-      if: always() && inputs.summary == 'true'
+      if: ${{ !cancelled() && steps.paths.outputs.summary != '' }}
       uses: actions/upload-artifact@v5
       with:
         name: ${{ inputs.artifact_name }}

--- a/validate-submission/action.yaml
+++ b/validate-submission/action.yaml
@@ -170,5 +170,8 @@ runs:
         name: ${{ inputs.artifact_name }}
         path: ${{ steps.paths.outputs.dir }}
         if-no-files-found: error
+        # Re-runs share the workflow run, and v4+ artifacts are immutable, so
+        # without this the upload 409s on every re-run attempt.
+        overwrite: true
         # Read by the companion workflow moments later, then dead.
         retention-days: 1

--- a/validate-submission/action.yaml
+++ b/validate-submission/action.yaml
@@ -54,6 +54,13 @@ inputs:
   show_warnings:
     description: "Print check-level warnings inline with their checks (true/false)."
     default: "false"
+  summary_path:
+    description: >-
+      Path to write a markdown summary of the check results to, for posting back
+      to the pull request. Empty writes no summary. Setting it also diverts the
+      check results through the file, so the workflow log shows them without
+      colour.
+    default: ""
   # environment / setup
   extra_packages:
     description: >-
@@ -106,4 +113,5 @@ runs:
         DERIVED_TASK_IDS: ${{ inputs.derived_task_ids }}
         VERBOSE: ${{ inputs.verbose }}
         SHOW_WARNINGS: ${{ inputs.show_warnings }}
+        SUMMARY_PATH: ${{ inputs.summary_path }}
       run: Rscript "${GITHUB_ACTION_PATH}/validate.R"

--- a/validate-submission/action.yaml
+++ b/validate-submission/action.yaml
@@ -54,13 +54,16 @@ inputs:
   show_warnings:
     description: "Print check-level warnings inline with their checks (true/false)."
     default: "false"
-  summary_path:
+  summary:
     description: >-
-      Path to write a markdown summary of the check results to, for posting back
-      to the pull request. Empty writes no summary. Setting it also diverts the
-      check results through the file, so the workflow log shows them without
-      colour.
-    default: ""
+      Write a markdown summary of the check results and upload it as an artifact,
+      for a companion workflow to post back to the pull request (true/false).
+    default: "false"
+  artifact_name:
+    description: >-
+      Name of the artifact the summary is uploaded as. Must match the
+      `artifact_name` the companion comment workflow reads.
+    default: "submission-validation-results"
   # environment / setup
   extra_packages:
     description: >-
@@ -74,9 +77,31 @@ inputs:
     description: "Token used to read pull request files via the GitHub API."
     default: ${{ github.token }}
 
+outputs:
+  summary-path:
+    description: "Path the markdown summary was written to. Empty unless `summary` is enabled."
+    value: ${{ steps.paths.outputs.summary }}
+
 runs:
   using: composite
   steps:
+    # One place decides where the summary lives, so nothing downstream has to
+    # agree with a path spelled out in a caller's workflow.
+    - id: paths
+      shell: bash
+      env:
+        WANTED: ${{ inputs.summary }}
+      run: |
+        if [ "$WANTED" != "true" ]; then
+          echo "dir=" >> "$GITHUB_OUTPUT"
+          echo "summary=" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        dir="${RUNNER_TEMP}/validate-submission"
+        mkdir -p "$dir"
+        echo "dir=$dir" >> "$GITHUB_OUTPUT"
+        echo "summary=$dir/summary.md" >> "$GITHUB_OUTPUT"
+
     - uses: r-lib/actions/setup-r@v2
       with:
         install-r: false
@@ -113,5 +138,34 @@ runs:
         DERIVED_TASK_IDS: ${{ inputs.derived_task_ids }}
         VERBOSE: ${{ inputs.verbose }}
         SHOW_WARNINGS: ${{ inputs.show_warnings }}
-        SUMMARY_PATH: ${{ inputs.summary_path }}
+        SUMMARY_PATH: ${{ steps.paths.outputs.summary }}
       run: Rscript "${GITHUB_ACTION_PATH}/validate.R"
+
+    # Validation writes no summary if it never got as far as running — a failed
+    # apt update, an r-universe outage. Without this the artifact would carry
+    # nothing to post and the submitter would be back to a bare red cross.
+    - name: Fall back to a summary if validation could not run
+      if: always() && inputs.summary == 'true'
+      shell: bash
+      env:
+        SUMMARY: ${{ steps.paths.outputs.summary }}
+      run: |
+        if [ -s "$SUMMARY" ]; then
+          exit 0
+        fi
+        mkdir -p "$(dirname "$SUMMARY")"
+        cat > "$SUMMARY" <<'EOF'
+        ## Submission validation
+
+        :x: **Validation did not complete.** The workflow failed before it could check this submission, which usually points at the hub's CI rather than the submission itself. The workflow log has the detail.
+        EOF
+
+    - name: Upload the summary
+      if: always() && inputs.summary == 'true'
+      uses: actions/upload-artifact@v5
+      with:
+        name: ${{ inputs.artifact_name }}
+        path: ${{ steps.paths.outputs.dir }}
+        if-no-files-found: error
+        # Read by the companion workflow moments later, then dead.
+        retention-days: 1

--- a/validate-submission/summary.R
+++ b/validate-submission/summary.R
@@ -77,8 +77,7 @@ truncate_lines <- function(lines, budget = BODY_BUDGET) {
 # length that content could match.
 fence <- function(lines) {
   runs <- unlist(regmatches(lines, gregexpr("`+", lines)))
-  longest <- if (length(runs) > 0L) max(nchar(runs)) else 0L
-  ticks <- strrep("`", max(4L, longest + 1L))
+  ticks <- strrep("`", max(4L, nchar(runs) + 1L))
   c(paste0(ticks, "text"), lines, ticks)
 }
 
@@ -114,10 +113,12 @@ render_summary <- function(lines, failure) {
 }
 
 # Reported when validation could not be run at all, so the pull request says so
-# rather than showing nothing but a failed check.
+# rather than showing nothing but a failed check. Split on newlines because
+# truncation works a line at a time: as one string an oversized message would cut
+# to nothing but the "lines omitted" notice.
 render_exec_error <- function(message) {
   summary_doc(
     ":x: **Validation could not be run.** This is usually a problem with the hub rather than the submission, so ask the hub administrators to take a look.",
-    message
+    strsplit(message, "\n", fixed = TRUE)[[1]]
   )
 }

--- a/validate-submission/summary.R
+++ b/validate-submission/summary.R
@@ -1,0 +1,123 @@
+# Turning validation results into a markdown summary for a pull request comment.
+#
+# Kept apart from validate.R, which reads the action's inputs and orchestrates
+# the run, so that these can be exercised without a hub or a GitHub API call.
+# See tests/test-summary.R.
+
+HEADING <- "## Submission validation"
+
+# GitHub rejects a comment body over 65,536 characters outright, so a submission
+# touching enough files to run past that would otherwise get no comment at all.
+# Budgeted short of the limit to leave room for the surrounding markdown and the
+# marker pr-comment prepends.
+BODY_BUDGET <- 55000L
+
+# Run check_for_errors() with its console output diverted, returning that output
+# alongside the failure message (NULL when everything passed). cli writes to the
+# message stream but validation-level warnings are cat()ed to stdout, so both are
+# sinked. Colour is off because cli treats GitHub Actions as colour-capable and
+# the escapes would end up in the comment; width is pinned so the summary does
+# not reflow with the runner's console.
+capture_check <- function(v, verbose = TRUE, show_warnings = FALSE) {
+  old <- options(cli.num_colors = 1, cli.width = 80)
+  on.exit(options(old), add = TRUE)
+
+  path <- tempfile("check-for-errors", fileext = ".txt")
+  con <- file(path, open = "w", encoding = "UTF-8")
+  failure <- local({
+    sink(con, type = "output")
+    sink(con, type = "message")
+    on.exit(
+      {
+        sink(type = "message")
+        sink(type = "output")
+        close(con)
+      },
+      add = TRUE
+    )
+    tryCatch(
+      {
+        hubValidations::check_for_errors(
+          v,
+          verbose = verbose,
+          show_warnings = show_warnings
+        )
+        NULL
+      },
+      error = function(e) conditionMessage(e)
+    )
+  })
+
+  list(
+    failure = failure,
+    lines = readLines(path, encoding = "UTF-8", warn = FALSE)
+  )
+}
+
+# Keeps the tail, because check_for_errors() prints the failing checks last.
+truncate_lines <- function(lines, budget = BODY_BUDGET) {
+  sizes <- nchar(lines, type = "bytes") + 1L
+  if (sum(sizes) <= budget) {
+    return(lines)
+  }
+  keep <- rev(cumsum(rev(sizes)) <= budget)
+  c(
+    sprintf(
+      "[... %d earlier lines omitted, see the workflow log for the full output ...]",
+      sum(!keep)
+    ),
+    lines[keep]
+  )
+}
+
+# The console output is embedded verbatim rather than converted, so the fence has
+# to survive whatever a check message contains. Check messages carry submitter
+# controlled text (file names, model IDs, config values), so the fence is made
+# one backtick longer than the longest run in the content rather than fixed at a
+# length that content could match.
+fence <- function(lines) {
+  runs <- unlist(regmatches(lines, gregexpr("`+", lines)))
+  longest <- if (length(runs) > 0L) max(nchar(runs)) else 0L
+  ticks <- strrep("`", max(4L, longest + 1L))
+  c(paste0(ticks, "text"), lines, ticks)
+}
+
+summary_doc <- function(status, lines, collapse = FALSE) {
+  block <- fence(truncate_lines(lines))
+  if (collapse) {
+    block <- c(
+      "<details><summary>Check results</summary>",
+      "",
+      block,
+      "",
+      "</details>"
+    )
+  }
+  c(HEADING, "", status, "", block)
+}
+
+# A passing run collapses the detail; a failure is what the submitter opened the
+# pull request to find out about, so it stays expanded.
+render_summary <- function(lines, failure) {
+  if (is.null(failure)) {
+    summary_doc(
+      ":white_check_mark: **All validation checks passed.**",
+      lines,
+      collapse = TRUE
+    )
+  } else {
+    summary_doc(
+      ":x: **Validation failed.** The checks below did not pass. Push a new commit to the pull request to re-run them.",
+      lines
+    )
+  }
+}
+
+# Reported when validation could not be run at all, so the pull request says so
+# rather than showing nothing but a failed check.
+render_exec_error <- function(message) {
+  summary_doc(
+    ":x: **Validation could not be run.** This is usually a problem with the hub rather than the submission, so ask the hub administrators to take a look.",
+    message
+  )
+}

--- a/validate-submission/summary.R
+++ b/validate-submission/summary.R
@@ -54,6 +54,15 @@ capture_check <- function(v, verbose = TRUE, show_warnings = FALSE) {
   )
 }
 
+CUT_NOTE <- " [... rest of line omitted ...]"
+
+# Cut to a byte budget, but on a character boundary so the result is still valid
+# UTF-8.
+cut_line <- function(line, budget) {
+  widths <- nchar(strsplit(line, "")[[1]], type = "bytes")
+  paste0(substr(line, 1L, sum(cumsum(widths) <= budget)), CUT_NOTE)
+}
+
 # Keeps the tail, because check_for_errors() prints the failing checks last.
 truncate_lines <- function(lines, budget = BODY_BUDGET) {
   sizes <- nchar(lines, type = "bytes") + 1L
@@ -61,12 +70,23 @@ truncate_lines <- function(lines, budget = BODY_BUDGET) {
     return(lines)
   }
   keep <- rev(cumsum(rev(sizes)) <= budget)
-  c(
-    sprintf(
-      "[... %d earlier lines omitted, see the workflow log for the full output ...]",
-      sum(!keep)
-    ),
+  kept <- if (any(keep)) {
     lines[keep]
+  } else {
+    # A line longer than the whole budget fits nowhere, which would drop the tail
+    # this function exists to keep and leave the notice on its own. Cut into that
+    # line instead, so some of the failing detail survives.
+    cut_line(lines[length(lines)], budget - nchar(CUT_NOTE, type = "bytes") - 1L)
+  }
+  omitted <- length(lines) - length(kept)
+  c(
+    if (omitted > 0L) {
+      sprintf(
+        "[... %d earlier lines omitted, see the workflow log for the full output ...]",
+        omitted
+      )
+    },
+    kept
   )
 }
 

--- a/validate-submission/tests/test-summary.R
+++ b/validate-submission/tests/test-summary.R
@@ -1,0 +1,169 @@
+# Tests for summary.R, the markdown a submitter sees on their pull request.
+#
+# Run with: Rscript validate-submission/tests/test-summary.R
+#
+# Deliberately free of hub and GitHub API access: validation objects come from
+# the test hubs bundled with hubValidations, so this needs no fixtures of its own
+# and no token. The pull request end of the flow is exercised by the pr-comment
+# self-tests, and the pieces in between only by running against a real hub.
+
+args <- commandArgs(trailingOnly = FALSE)
+here <- dirname(sub("^--file=", "", grep("^--file=", args, value = TRUE)[1]))
+source(file.path(here, "..", "summary.R"))
+
+failures <- 0L
+
+expect <- function(ok, what) {
+  if (isTRUE(ok)) {
+    cat("ok   -", what, "\n")
+  } else {
+    cat("FAIL -", what, "\n")
+    failures <<- failures + 1L
+  }
+}
+
+hub <- system.file("testhubs/simple", package = "hubValidations")
+
+validate_file <- function(file_path) {
+  hubValidations::validate_submission(
+    hub,
+    file_path = file_path,
+    skip_submit_window_check = TRUE
+  )
+}
+
+# --- a submission that passes ------------------------------------------------
+
+good <- validate_file("team1-goodmodel/2022-10-08-team1-goodmodel.csv")
+pass <- capture_check(good)
+
+expect(is.null(pass$failure), "a passing submission reports no failure")
+expect(
+  any(grepl("All validation checks have been successful", pass$lines)),
+  "the success message is captured"
+)
+expect(
+  !any(grepl("\033", pass$lines)),
+  "captured output carries no ANSI escapes"
+)
+
+pass_md <- render_summary(pass$lines, pass$failure)
+expect(
+  any(grepl("All validation checks passed", pass_md, fixed = TRUE)),
+  "a pass renders the success heading"
+)
+expect(
+  any(grepl("<details>", pass_md, fixed = TRUE)),
+  "a pass collapses the detail"
+)
+
+# --- a submission that fails --------------------------------------------------
+
+fail <- capture_check(validate_file("team1-goodmodel/2022-10-15-hub-baseline.csv"))
+
+expect(!is.null(fail$failure), "a failing submission reports a failure")
+expect(
+  any(grepl("file_location", fail$lines, fixed = TRUE)),
+  "the failing check is captured"
+)
+
+fail_md <- render_summary(fail$lines, fail$failure)
+expect(
+  any(grepl("Validation failed", fail_md, fixed = TRUE)),
+  "a failure renders the failure heading"
+)
+expect(
+  !any(grepl("<details>", fail_md, fixed = TRUE)),
+  "a failure is not collapsed"
+)
+
+# --- both output streams are captured -----------------------------------------
+
+# cli writes to the message stream, but print_validation_warnings() cat()s its
+# box to stdout. Sinking only one stream would silently drop the other.
+warned <- good
+attr(warned, "warnings") <- list(
+  hubValidations::capture_validation_warning(
+    msg = "A validation level warning that is cat()ed to stdout.",
+    where = "test"
+  )
+)
+warn <- capture_check(warned)
+
+expect(
+  any(grepl("cat\\(\\)ed to stdout", warn$lines)),
+  "validation-level warnings (stdout) are captured"
+)
+expect(
+  any(grepl("check results", warn$lines, ignore.case = TRUE)),
+  "cli output (message stream) is captured alongside them"
+)
+
+# --- the code fence survives hostile content ----------------------------------
+
+hostile <- render_summary(
+  c("x [check]: a message containing ```", "```", "## not a heading"),
+  "failed"
+)
+
+expect(
+  sum(grepl("^````", hostile)) == 2L,
+  "the fence is opened and closed with four backticks"
+)
+closing <- max(which(hostile == "````"))
+expect(
+  which(hostile == "## not a heading") < closing,
+  "content after a three-backtick line stays inside the fence"
+)
+
+# Four backticks in the content would match a fixed four-backtick fence, so the
+# fence has to grow past whatever the content holds.
+longer <- render_summary(c("a message containing ``````", "still inside"), "failed")
+ticks <- grep("^`+", longer, value = TRUE)
+expect(
+  nchar(sub("text$", "", ticks[1])) == 7L,
+  "the fence outgrows the longest backtick run in the content"
+)
+expect(
+  which(longer == "still inside") < max(which(longer == ticks[length(ticks)])),
+  "content after a six-backtick line stays inside the fence"
+)
+
+# --- oversized output is truncated, not rejected by GitHub ---------------------
+
+big <- render_summary(rep("a line of check output that is not especially short", 4000), "failed")
+expect(
+  sum(nchar(big)) + length(big) < 65536L,
+  "an oversized summary is brought under GitHub's comment limit"
+)
+expect(
+  any(grepl("earlier lines omitted", big, fixed = TRUE)),
+  "truncation says so"
+)
+expect(
+  tail(big, 1L) == grep("^`+$", big, value = TRUE)[1] &&
+    any(grepl("check output", tail(big, 5L))),
+  "truncation keeps the end, where the failing checks are"
+)
+
+# --- validation that could not run --------------------------------------------
+
+exec <- render_exec_error("Error: hub-config/tasks.json is not valid JSON.")
+
+expect(
+  any(grepl("could not be run", exec, fixed = TRUE)),
+  "an execution error renders its own heading"
+)
+expect(
+  any(grepl("tasks.json is not valid JSON", exec, fixed = TRUE)),
+  "an execution error includes the underlying message"
+)
+expect(sum(grepl("^````", exec)) == 2L, "an execution error is fenced too")
+
+# ------------------------------------------------------------------------------
+
+if (failures > 0L) {
+  cat("\n", failures, " check(s) failed.\n", sep = "")
+  quit(status = 1)
+}
+cat("\nAll checks passed.\n")

--- a/validate-submission/tests/test-summary.R
+++ b/validate-submission/tests/test-summary.R
@@ -144,6 +144,35 @@ expect(
   "truncation keeps the end, where the failing checks are"
 )
 
+# A line longer than the whole budget fits nowhere, so without a cut into it the
+# tail would be dropped and the summary would be the notice and nothing else.
+one_big_line <- render_summary(
+  c("an earlier line", paste0(strrep("z", 60000L), "the failing detail")),
+  "failed"
+)
+
+expect(
+  sum(nchar(one_big_line)) + length(one_big_line) < 65536L,
+  "a single oversized line is brought under the comment limit"
+)
+expect(
+  any(grepl("zzzz", one_big_line, fixed = TRUE)),
+  "a single oversized line still shows some of its content"
+)
+expect(
+  any(grepl("rest of line omitted", one_big_line, fixed = TRUE)),
+  "cutting into a line says so"
+)
+
+# The budget is in bytes, so a multibyte line has to be cut on a character
+# boundary to stay valid UTF-8 and inside the budget.
+multibyte <- truncate_lines(strrep("é", 40000L))
+expect(
+  sum(nchar(multibyte, type = "bytes")) <= BODY_BUDGET &&
+    !any(is.na(nchar(multibyte))),
+  "a multibyte line is cut on a character boundary, within the byte budget"
+)
+
 # --- validation that could not run --------------------------------------------
 
 exec <- render_exec_error("Error: hub-config/tasks.json is not valid JSON.")

--- a/validate-submission/tests/test-summary.R
+++ b/validate-submission/tests/test-summary.R
@@ -110,9 +110,8 @@ expect(
   sum(grepl("^````", hostile)) == 2L,
   "the fence is opened and closed with four backticks"
 )
-closing <- max(which(hostile == "````"))
 expect(
-  which(hostile == "## not a heading") < closing,
+  which(hostile == "## not a heading") < length(hostile),
   "content after a three-backtick line stays inside the fence"
 )
 
@@ -125,7 +124,7 @@ expect(
   "the fence outgrows the longest backtick run in the content"
 )
 expect(
-  which(longer == "still inside") < max(which(longer == ticks[length(ticks)])),
+  which(longer == "still inside") < length(longer),
   "content after a six-backtick line stays inside the fence"
 )
 
@@ -141,8 +140,7 @@ expect(
   "truncation says so"
 )
 expect(
-  tail(big, 1L) == grep("^`+$", big, value = TRUE)[1] &&
-    any(grepl("check output", tail(big, 5L))),
+  grepl("^`+$", tail(big, 1L)) && any(grepl("check output", tail(big, 5L))),
   "truncation keeps the end, where the failing checks are"
 )
 
@@ -159,6 +157,24 @@ expect(
   "an execution error includes the underlying message"
 )
 expect(sum(grepl("^````", exec)) == 2L, "an execution error is fenced too")
+
+# An R condition message is one string with embedded newlines. Truncation works a
+# line at a time, so without the split inside render_exec_error() an oversized
+# message would cut to nothing but the notice, leaving the submitter a "could not
+# be run" comment with no detail in it.
+exec_big <- render_exec_error(paste(
+  rep("Error in `read_config()`: something went wrong on this line.", 2000),
+  collapse = "\n"
+))
+
+expect(
+  sum(nchar(exec_big)) + length(exec_big) < 65536L,
+  "an oversized execution error is brought under the comment limit"
+)
+expect(
+  any(grepl("something went wrong", exec_big, fixed = TRUE)),
+  "an oversized execution error still shows some of the message"
+)
 
 # ------------------------------------------------------------------------------
 

--- a/validate-submission/validate-submission.yaml
+++ b/validate-submission/validate-submission.yaml
@@ -1,18 +1,16 @@
 name: Hub Submission Validation (R)
 
-# Two jobs, two triggers, one file.
+# Runs the checks on the pull request and saves the result. It cannot post that
+# result itself: most submissions come from forks, and a `pull_request` workflow
+# triggered from a fork gets a read-only GITHUB_TOKEN.
 #
-# `validate` runs on the pull request. It cannot post its own result: most
-# submissions come from forks, and a `pull_request` workflow triggered from a
-# fork gets a read-only GITHUB_TOKEN. It uploads the result instead.
+# The companion workflow posts it, running once this one finishes. Add both:
 #
-# `comment` then runs on this workflow finishing. That run belongs to your hub
-# rather than to the submitter, so it is allowed to comment, and it posts what
-# was uploaded. Its steps live in hubverse-actions rather than here, so that
-# fixes to them reach you without you having to add a new copy of this file.
+#   hubCI::use_hub_github_action("validate-submission")
+#   hubCI::use_hub_github_action("validate-submission-comment")
 #
-# The `workflows:` entry below must match this workflow's own `name:`. If you
-# change one, change the other, or results will silently stop being posted.
+# The companion matches this workflow by the `name:` above. If you change it,
+# change it there too, or results will quietly stop being posted.
 
 on:
   workflow_dispatch:
@@ -22,9 +20,6 @@ on:
       - 'model-output/**'
       - 'model-metadata/*'
       - '!**README**'
-  workflow_run:
-    workflows: ["Hub Submission Validation (R)"]
-    types: [completed]
 
 permissions:
   contents: read
@@ -32,7 +27,6 @@ permissions:
 
 jobs:
   validate:
-    if: github.event_name != 'workflow_run'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v7
@@ -48,11 +42,3 @@ jobs:
           # skip_submit_window_check: true
           # extra_packages: |
           #   any::mycustompkg
-
-  comment:
-    if: github.event_name == 'workflow_run'
-    uses: hubverse-org/hubverse-actions/.github/workflows/post-validation-comment.yaml@main
-    permissions:
-      contents: read
-      actions: read
-      pull-requests: write

--- a/validate-submission/validate-submission.yaml
+++ b/validate-submission/validate-submission.yaml
@@ -1,5 +1,11 @@
 name: Hub Submission Validation (R)
 
+# Posting the result back to the pull request needs a companion workflow, since
+# this one gets a read-only token on the fork pull requests most submissions come
+# from. Scaffold it with
+# hubCI::use_hub_github_action("validate-submission-comment"). Without it the
+# validation still runs and the summary is simply left as an artifact.
+
 on:
   workflow_dispatch:
   pull_request:
@@ -20,10 +26,30 @@ jobs:
       - uses: actions/checkout@v7
 
       - uses: hubverse-org/hubverse-actions/validate-submission@main
-        # Customise validation via inputs, e.g. to skip the submission window
-        # check or install extra packages for custom checks. See the action
-        # README for the full list.
-        # with:
-        #   skip_submit_window_check: true
-        #   extra_packages: |
-        #     any::mycustompkg
+        with:
+          # Where to write the markdown summary posted back to the pull request.
+          summary_path: ${{ runner.temp }}/validation/summary.md
+          # Customise validation with further inputs, e.g. to skip the submission
+          # window check or install extra packages for custom checks. See the
+          # action README for the full list.
+          # skip_submit_window_check: true
+          # extra_packages: |
+          #   any::mycustompkg
+
+      - name: Record the pull request number
+        if: always() && github.event_name == 'pull_request'
+        shell: bash
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+          SUMMARY_DIR: ${{ runner.temp }}/validation
+        run: |
+          mkdir -p "$SUMMARY_DIR"
+          printf '%s' "$PR_NUMBER" > "$SUMMARY_DIR/pr-number.txt"
+
+      - name: Upload the validation summary
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v5
+        with:
+          name: submission-validation
+          path: ${{ runner.temp }}/validation
+          if-no-files-found: error

--- a/validate-submission/validate-submission.yaml
+++ b/validate-submission/validate-submission.yaml
@@ -26,7 +26,15 @@ permissions:
   pull-requests: read
 
 jobs:
-  validate:
+  # Hubs put this job's name in their branch protection rules, so renaming it
+  # silently stops their required check from ever reporting.
+  validate-submission:
+    # Skip on forks of the hub. A submitter working in their own fork would
+    # otherwise see this run — and sometimes fail — against their copy, which is
+    # confusing and tells them nothing: the validation that decides whether their
+    # submission is accepted is the one that runs here, on their pull request.
+    # Delete this line if your hub does want forks to validate their own copies.
+    if: github.event.repository.fork != true
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v7

--- a/validate-submission/validate-submission.yaml
+++ b/validate-submission/validate-submission.yaml
@@ -1,10 +1,18 @@
 name: Hub Submission Validation (R)
 
-# Posting the result back to the pull request needs a companion workflow, since
-# this one gets a read-only token on the fork pull requests most submissions come
-# from. Scaffold it with
-# hubCI::use_hub_github_action("validate-submission-comment"). Without it the
-# validation still runs and the summary is simply left as an artifact.
+# Two jobs, two triggers, one file.
+#
+# `validate` runs on the pull request. It cannot post its own result: most
+# submissions come from forks, and a `pull_request` workflow triggered from a
+# fork gets a read-only GITHUB_TOKEN. It uploads the result instead.
+#
+# `comment` then runs on this workflow finishing. That run belongs to your hub
+# rather than to the submitter, so it is allowed to comment, and it posts what
+# was uploaded. Its steps live in hubverse-actions rather than here, so that
+# fixes to them reach you without you having to add a new copy of this file.
+#
+# The `workflows:` entry below must match this workflow's own `name:`. If you
+# change one, change the other, or results will silently stop being posted.
 
 on:
   workflow_dispatch:
@@ -14,21 +22,26 @@ on:
       - 'model-output/**'
       - 'model-metadata/*'
       - '!**README**'
+  workflow_run:
+    workflows: ["Hub Submission Validation (R)"]
+    types: [completed]
 
 permissions:
   contents: read
   pull-requests: read
 
 jobs:
-  validate-submission:
+  validate:
+    if: github.event_name != 'workflow_run'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v7
 
       - uses: hubverse-org/hubverse-actions/validate-submission@main
         with:
-          # Where to write the markdown summary posted back to the pull request.
-          summary_path: ${{ runner.temp }}/validation/summary.md
+          # Report the result on the pull request. Set to false to keep the
+          # result in the workflow log only.
+          summary: true
           # Customise validation with further inputs, e.g. to skip the submission
           # window check or install extra packages for custom checks. See the
           # action README for the full list.
@@ -36,20 +49,10 @@ jobs:
           # extra_packages: |
           #   any::mycustompkg
 
-      - name: Record the pull request number
-        if: always() && github.event_name == 'pull_request'
-        shell: bash
-        env:
-          PR_NUMBER: ${{ github.event.number }}
-          SUMMARY_DIR: ${{ runner.temp }}/validation
-        run: |
-          mkdir -p "$SUMMARY_DIR"
-          printf '%s' "$PR_NUMBER" > "$SUMMARY_DIR/pr-number.txt"
-
-      - name: Upload the validation summary
-        if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v5
-        with:
-          name: submission-validation
-          path: ${{ runner.temp }}/validation
-          if-no-files-found: error
+  comment:
+    if: github.event_name == 'workflow_run'
+    uses: hubverse-org/hubverse-actions/.github/workflows/post-validation-comment.yaml@main
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write

--- a/validate-submission/validate.R
+++ b/validate-submission/validate.R
@@ -54,6 +54,7 @@ fail <- function(message) {
   quit(status = 1)
 }
 
+# The action creates this directory when it decides where the summary goes.
 summary_path <- Sys.getenv("SUMMARY_PATH")
 
 if (!nzchar(summary_path)) {
@@ -62,40 +63,40 @@ if (!nzchar(summary_path)) {
     verbose = env_lgl("VERBOSE"),
     show_warnings = env_lgl("SHOW_WARNINGS")
   )
-} else {
-  dir.create(dirname(summary_path), recursive = TRUE, showWarnings = FALSE)
+  quit(status = 0)
+}
 
-  v <- tryCatch(validate(), error = identity)
-  if (inherits(v, "error")) {
-    writeLines(
-      render_exec_error(conditionMessage(v)),
-      summary_path,
-      useBytes = TRUE
-    )
-    writeLines(conditionMessage(v), stderr())
-    fail(
-      "Submission validation could not be run. See the pull request comment, or the error above, for details."
-    )
-  }
+# Colour off for the same reason capture_check() disables it: cli treats GitHub
+# Actions as colour-capable, and an aborting check formats its message at throw
+# time, so the escapes would otherwise land in the comment.
+options(cli.num_colors = 1)
 
-  checked <- capture_check(
-    v,
-    verbose = env_lgl("VERBOSE"),
-    show_warnings = env_lgl("SHOW_WARNINGS")
+v <- tryCatch(validate(), error = identity)
+if (inherits(v, "error")) {
+  writeLines(render_exec_error(conditionMessage(v)), summary_path, useBytes = TRUE)
+  writeLines(conditionMessage(v), stderr())
+  fail(
+    "Submission validation could not be run. See the pull request comment, or the error above, for details."
   )
+}
 
-  writeLines(
-    render_summary(checked$lines, checked$failure),
-    summary_path,
-    useBytes = TRUE
+checked <- capture_check(
+  v,
+  verbose = env_lgl("VERBOSE"),
+  show_warnings = env_lgl("SHOW_WARNINGS")
+)
+
+writeLines(
+  render_summary(checked$lines, checked$failure),
+  summary_path,
+  useBytes = TRUE
+)
+
+# The console output was diverted, so replay it into the workflow log.
+writeLines(checked$lines, stderr())
+
+if (!is.null(checked$failure)) {
+  fail(
+    "Submission validation failed. See the pull request comment, or the check results above, for details."
   )
-
-  # The console output was diverted, so replay it into the workflow log.
-  writeLines(checked$lines, stderr())
-
-  if (!is.null(checked$failure)) {
-    fail(
-      "Submission validation failed. See the pull request comment, or the check results above, for details."
-    )
-  }
 }

--- a/validate-submission/validate.R
+++ b/validate-submission/validate.R
@@ -26,22 +26,129 @@ env_csv <- function(name) {
   trimws(strsplit(value, ",", fixed = TRUE)[[1]])
 }
 
-v <- hubValidations::validate_pr(
-  hub_path = Sys.getenv("HUB_PATH"),
-  gh_repo = Sys.getenv("GH_REPO"),
-  pr_number = Sys.getenv("PR_NUMBER"),
-  round_id_col = env_or_null("ROUND_ID_COL"),
-  output_type_id_datatype = Sys.getenv("OUTPUT_TYPE_ID_DATATYPE"),
-  validations_cfg_path = env_or_null("VALIDATIONS_CFG_PATH"),
-  skip_submit_window_check = env_lgl("SKIP_SUBMIT_WINDOW_CHECK"),
-  file_modification_check = Sys.getenv("FILE_MODIFICATION_CHECK"),
-  allow_submit_window_mods = env_lgl("ALLOW_SUBMIT_WINDOW_MODS"),
-  submit_window_ref_date_from = Sys.getenv("SUBMIT_WINDOW_REF_DATE_FROM"),
-  derived_task_ids = env_csv("DERIVED_TASK_IDS")
-)
+# Run check_for_errors() with its console output diverted to `path`, returning
+# the failure message or NULL on success. cli writes to the message stream but
+# validation-level warnings are cat()ed to stdout, so both are sinked. Colour is
+# off because cli treats GitHub Actions as colour-capable and the escapes would
+# end up in the comment; width is pinned so the summary does not reflow with the
+# runner's console.
+capture_check <- function(v, path) {
+  old <- options(cli.num_colors = 1, cli.width = 80)
+  on.exit(options(old), add = TRUE)
+  con <- file(path, open = "w", encoding = "UTF-8")
+  sink(con, type = "output")
+  sink(con, type = "message")
+  on.exit(
+    {
+      sink(type = "message")
+      sink(type = "output")
+      close(con)
+    },
+    add = TRUE
+  )
+  tryCatch(
+    {
+      hubValidations::check_for_errors(
+        v,
+        verbose = env_lgl("VERBOSE"),
+        show_warnings = env_lgl("SHOW_WARNINGS")
+      )
+      NULL
+    },
+    error = function(e) conditionMessage(e)
+  )
+}
 
-hubValidations::check_for_errors(
-  v,
-  verbose = env_lgl("VERBOSE"),
-  show_warnings = env_lgl("SHOW_WARNINGS")
-)
+# Wrap the captured console output in a markdown report for the PR comment.
+# Failures are shown expanded; a passing run collapses the detail.
+render_summary <- function(lines, failure) {
+  fence <- c("```text", lines, "```")
+  if (is.null(failure)) {
+    c(
+      "## Submission validation",
+      "",
+      ":white_check_mark: **All validation checks passed.**",
+      "",
+      "<details><summary>Check results</summary>",
+      "",
+      fence,
+      "",
+      "</details>"
+    )
+  } else {
+    c(
+      "## Submission validation",
+      "",
+      ":x: **Validation failed.** The checks below did not pass. Push a new commit to the pull request to re-run them.",
+      "",
+      fence
+    )
+  }
+}
+
+# Reported when validation could not be run at all, so the pull request says so
+# rather than showing nothing but a failed check.
+render_exec_error <- function(message) {
+  c(
+    "## Submission validation",
+    "",
+    ":x: **Validation could not be run.** This is usually a problem with the hub rather than the submission, so ask the hub administrators to take a look.",
+    "",
+    "```text",
+    message,
+    "```"
+  )
+}
+
+validate <- function() {
+  hubValidations::validate_pr(
+    hub_path = Sys.getenv("HUB_PATH"),
+    gh_repo = Sys.getenv("GH_REPO"),
+    pr_number = Sys.getenv("PR_NUMBER"),
+    round_id_col = env_or_null("ROUND_ID_COL"),
+    output_type_id_datatype = Sys.getenv("OUTPUT_TYPE_ID_DATATYPE"),
+    validations_cfg_path = env_or_null("VALIDATIONS_CFG_PATH"),
+    skip_submit_window_check = env_lgl("SKIP_SUBMIT_WINDOW_CHECK"),
+    file_modification_check = Sys.getenv("FILE_MODIFICATION_CHECK"),
+    allow_submit_window_mods = env_lgl("ALLOW_SUBMIT_WINDOW_MODS"),
+    submit_window_ref_date_from = Sys.getenv("SUBMIT_WINDOW_REF_DATE_FROM"),
+    derived_task_ids = env_csv("DERIVED_TASK_IDS")
+  )
+}
+
+fail <- function(message) {
+  cat(paste0("::error::", message, "\n"))
+  quit(status = 1)
+}
+
+summary_path <- Sys.getenv("SUMMARY_PATH")
+
+if (!nzchar(summary_path)) {
+  hubValidations::check_for_errors(
+    validate(),
+    verbose = env_lgl("VERBOSE"),
+    show_warnings = env_lgl("SHOW_WARNINGS")
+  )
+} else {
+  dir.create(dirname(summary_path), recursive = TRUE, showWarnings = FALSE)
+
+  v <- tryCatch(validate(), error = identity)
+  if (inherits(v, "error")) {
+    writeLines(render_exec_error(conditionMessage(v)), summary_path, useBytes = TRUE)
+    writeLines(conditionMessage(v), stderr())
+    fail("Submission validation could not be run. See the pull request comment, or the error above, for details.")
+  }
+
+  console_path <- file.path(tempdir(), "check-for-errors.txt")
+  failure <- capture_check(v, console_path)
+  lines <- readLines(console_path, encoding = "UTF-8", warn = FALSE)
+
+  writeLines(render_summary(lines, failure), summary_path, useBytes = TRUE)
+
+  # The console output was diverted, so replay it into the workflow log.
+  writeLines(lines, stderr())
+
+  if (!is.null(failure)) {
+    fail("Submission validation failed. See the pull request comment, or the check results above, for details.")
+  }
+}

--- a/validate-submission/validate.R
+++ b/validate-submission/validate.R
@@ -9,6 +9,13 @@
 # Input defaults live in action.yaml, which always sets these variables, so this
 # script does not restate them.
 
+script_dir <- function() {
+  args <- commandArgs(trailingOnly = FALSE)
+  dirname(sub("^--file=", "", grep("^--file=", args, value = TRUE)[1]))
+}
+
+source(file.path(script_dir(), "summary.R"))
+
 env_or_null <- function(name) {
   value <- Sys.getenv(name)
   if (nzchar(value)) value else NULL
@@ -24,80 +31,6 @@ env_csv <- function(name) {
     return(NULL)
   }
   trimws(strsplit(value, ",", fixed = TRUE)[[1]])
-}
-
-# Run check_for_errors() with its console output diverted to `path`, returning
-# the failure message or NULL on success. cli writes to the message stream but
-# validation-level warnings are cat()ed to stdout, so both are sinked. Colour is
-# off because cli treats GitHub Actions as colour-capable and the escapes would
-# end up in the comment; width is pinned so the summary does not reflow with the
-# runner's console.
-capture_check <- function(v, path) {
-  old <- options(cli.num_colors = 1, cli.width = 80)
-  on.exit(options(old), add = TRUE)
-  con <- file(path, open = "w", encoding = "UTF-8")
-  sink(con, type = "output")
-  sink(con, type = "message")
-  on.exit(
-    {
-      sink(type = "message")
-      sink(type = "output")
-      close(con)
-    },
-    add = TRUE
-  )
-  tryCatch(
-    {
-      hubValidations::check_for_errors(
-        v,
-        verbose = env_lgl("VERBOSE"),
-        show_warnings = env_lgl("SHOW_WARNINGS")
-      )
-      NULL
-    },
-    error = function(e) conditionMessage(e)
-  )
-}
-
-# Wrap the captured console output in a markdown report for the PR comment.
-# Failures are shown expanded; a passing run collapses the detail.
-render_summary <- function(lines, failure) {
-  fence <- c("```text", lines, "```")
-  if (is.null(failure)) {
-    c(
-      "## Submission validation",
-      "",
-      ":white_check_mark: **All validation checks passed.**",
-      "",
-      "<details><summary>Check results</summary>",
-      "",
-      fence,
-      "",
-      "</details>"
-    )
-  } else {
-    c(
-      "## Submission validation",
-      "",
-      ":x: **Validation failed.** The checks below did not pass. Push a new commit to the pull request to re-run them.",
-      "",
-      fence
-    )
-  }
-}
-
-# Reported when validation could not be run at all, so the pull request says so
-# rather than showing nothing but a failed check.
-render_exec_error <- function(message) {
-  c(
-    "## Submission validation",
-    "",
-    ":x: **Validation could not be run.** This is usually a problem with the hub rather than the submission, so ask the hub administrators to take a look.",
-    "",
-    "```text",
-    message,
-    "```"
-  )
 }
 
 validate <- function() {
@@ -134,21 +67,35 @@ if (!nzchar(summary_path)) {
 
   v <- tryCatch(validate(), error = identity)
   if (inherits(v, "error")) {
-    writeLines(render_exec_error(conditionMessage(v)), summary_path, useBytes = TRUE)
+    writeLines(
+      render_exec_error(conditionMessage(v)),
+      summary_path,
+      useBytes = TRUE
+    )
     writeLines(conditionMessage(v), stderr())
-    fail("Submission validation could not be run. See the pull request comment, or the error above, for details.")
+    fail(
+      "Submission validation could not be run. See the pull request comment, or the error above, for details."
+    )
   }
 
-  console_path <- file.path(tempdir(), "check-for-errors.txt")
-  failure <- capture_check(v, console_path)
-  lines <- readLines(console_path, encoding = "UTF-8", warn = FALSE)
+  checked <- capture_check(
+    v,
+    verbose = env_lgl("VERBOSE"),
+    show_warnings = env_lgl("SHOW_WARNINGS")
+  )
 
-  writeLines(render_summary(lines, failure), summary_path, useBytes = TRUE)
+  writeLines(
+    render_summary(checked$lines, checked$failure),
+    summary_path,
+    useBytes = TRUE
+  )
 
   # The console output was diverted, so replay it into the workflow log.
-  writeLines(lines, stderr())
+  writeLines(checked$lines, stderr())
 
-  if (!is.null(failure)) {
-    fail("Submission validation failed. See the pull request comment, or the check results above, for details.")
+  if (!is.null(checked$failure)) {
+    fail(
+      "Submission validation failed. See the pull request comment, or the check results above, for details."
+    )
   }
 }


### PR DESCRIPTION
Resolves #53. Resolves #63.

A submitter sees only a red ✗ today and has to open the Actions log to find out why. Validation now writes up its result and posts it as a comment on the pull request. [Preview of the four comment shapes](https://claude.ai/code/artifact/d1c583b1-e2ec-48a3-b30e-4c0caccd100c) — real output, not mock-ups.

```mermaid
flowchart TB
    A["Submission pull request<br/>(usually from a fork)"]
    subgraph s1["Stage 1 · on the pull request · read-only"]
        B["validation workflow"] --> C["validate-submission action"] --> D[("result file")]
    end
    subgraph s2["Stage 2 · as the hub · allowed to comment"]
        E["comment workflow"] --> F["post-validation-comment<br/>shared workflow"] --> G["resolve-pr"] --> H["pr-comment"]
    end
    A --> B
    D -. "stage 1 finishes, starting stage 2;<br/>file picked up but not trusted" .-> E
    H --> I["Result on the pull request"]
```

## What each piece does

- **validation workflow** (`validate-submission/validate-submission.yaml`) — the first file a hub adds; runs on the pull request and calls the action below.
- **`validate-submission` action** — sets up R, runs `hubValidations::validate_pr()`, writes the result up as markdown, and saves it to the run.
- **result file** — that write-up, stored as an artifact, which is the only thing that crosses from stage 1 to stage 2.
- **comment workflow** (`validate-submission-comment/validate-submission-comment.yaml`) — the second file a hub adds; runs when the first one finishes and calls the shared workflow below.
- **`post-validation-comment`** (new, shared) — holds the three posting steps, kept in this repo rather than in the hub's copy so fixes reach every hub without re-scaffolding.
- **`resolve-pr`** (new action) — works out which pull request the run came from, using GitHub's own record of what triggered it rather than anything a submitter can write.
- **`pr-comment`** (existing action) — posts the comment, or edits the existing one for that commit in place.

## Why two workflows

Fork PRs get a read-only token, so the job running the checks can't comment. It saves the result instead, and a second workflow posts it as the hub. That has to be a **separate file** — GitHub rejects a workflow that names itself as its own trigger. Hubs add both:

```r
hubCI::use_hub_github_action("validate-submission")
hubCI::use_hub_github_action("validate-submission-comment")
```

Two calls for now — hubverse-org/hubCI#26 will make the first one install its companion automatically.

Stage 2 never trusts the saved file: a fork runs its own copy of stage 1 and controls what goes into it, so the target PR comes from the trigger via the new `resolve-pr` action, never from the artifact. Neither workflow runs on forks of the hub (#63).

## For the reviewer

- **The comment half can't go green here.** `workflow_run` only fires for workflows already on the default branch, so it starts working after merge. The `summary` job and the `ci-testhub-simple` fixture jobs are the real pre-merge signal.
- Touches `pr-comment` (merged in #60) to add a per-revision footer and tighten which comments it will adopt.
- `post-validation-comment.yaml` sits in `.github/workflows/` because GitHub only recognises reusable workflows there.
- Still pinned to `ubuntu-22.04`: 24.04 ships no R and we set `install-r: false`. #64 removes that dependency next.
