### PR TITLE
Install R rather than depend on the runner image shipping it

### DIFF
--- a/.github/workflows/post-validation-comment.yaml
+++ b/.github/workflows/post-validation-comment.yaml
@@ -52,7 +52,7 @@ jobs:
     if: >-
       github.event.workflow_run.event == 'pull_request' &&
       contains(fromJSON('["success", "failure"]'), github.event.workflow_run.conclusion)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     # Serialise re-runs of one revision: pr-comment's create-or-update is not
     # atomic, so two of them finishing together could each post a comment. Keyed
     # on the commit rather than the branch because runs for different revisions

--- a/.github/workflows/test-pr-comment.yaml
+++ b/.github/workflows/test-pr-comment.yaml
@@ -21,7 +21,7 @@ jobs:
     # Fork PRs get a read-only GITHUB_TOKEN and cannot post comments, so these
     # self-tests can only run on same-repo PRs.
     if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
 
@@ -81,7 +81,7 @@ jobs:
 
   revision:
     if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
 
@@ -180,7 +180,7 @@ jobs:
   invalid-inputs:
     # The input guards run before any API call, so no comment is posted and this
     # job works on fork PRs too, where the read-only token blocks the jobs above.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/test-submission-comment-post.yaml
+++ b/.github/workflows/test-submission-comment-post.yaml
@@ -33,7 +33,7 @@ jobs:
     # own red run is the signal — asserting here would just double-report it.
     if: github.event.workflow_run.conclusion == 'success'
     needs: comment
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/test-submission-comment.yaml
+++ b/.github/workflows/test-submission-comment.yaml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   upload:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Stand in for a validation summary
         shell: bash

--- a/.github/workflows/test-validate-submission.yaml
+++ b/.github/workflows/test-validate-submission.yaml
@@ -26,18 +26,14 @@ jobs:
   # as test hubs. No hub checkout and no token, so it covers rendering the fixture
   # PRs cannot reach, such as oversized output and a run that never got started.
   summary:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
 
       - uses: r-lib/actions/setup-r@v2
         with:
-          install-r: false
           use-public-rspm: true
           extra-repositories: 'https://hubverse-org.r-universe.dev'
-
-      - name: Update apt
-        run: sudo apt-get update
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         env:
@@ -54,7 +50,7 @@ jobs:
         run: Rscript validate-submission/tests/test-summary.R
 
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/cache-hubval-deps/cache-hubval-deps.yaml
+++ b/cache-hubval-deps/cache-hubval-deps.yaml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   build-deps-cache-on-main:
     if: github.event.repository.fork != true
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
@@ -22,13 +22,8 @@ jobs:
 
       - uses: r-lib/actions/setup-r@v2
         with:
-          install-r: false
           use-public-rspm: true
           extra-repositories: 'https://hubverse-org.r-universe.dev'
-
-      - name: Update R
-        run: |
-          sudo apt-get update
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/hubverse-aws-upload/hubverse-aws-upload.yaml
+++ b/hubverse-aws-upload/hubverse-aws-upload.yaml
@@ -18,7 +18,7 @@ jobs:
   upload:
     # Don't run on forked repositories
     if: github.event.repository.fork != true
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout

--- a/validate-config/README.md
+++ b/validate-config/README.md
@@ -35,7 +35,7 @@ For example, to validate the config of a demo hub included as part of a package 
  
  jobs:
    validate-hub-config:
-     runs-on: ubuntu-22.04
+     runs-on: ubuntu-latest
      env:
        GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
        PR_NUMBER: ${{ github.event.number }}

--- a/validate-config/validate-config.yaml
+++ b/validate-config/validate-config.yaml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   validate-hub-config:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       PR_NUMBER: ${{ github.event.number }}
@@ -26,13 +26,8 @@ jobs:
 
       - uses: r-lib/actions/setup-r@v2
         with:
-          install-r: false
           use-public-rspm: true
           extra-repositories: 'https://hubverse-org.r-universe.dev'
-
-      - name: Update R
-        run: |
-          sudo apt-get update
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/validate-submission/action.yaml
+++ b/validate-submission/action.yaml
@@ -105,13 +105,8 @@ runs:
 
     - uses: r-lib/actions/setup-r@v2
       with:
-        install-r: false
         use-public-rspm: true
         extra-repositories: ${{ inputs.extra_repositories }}
-
-    - name: Update apt
-      shell: bash
-      run: sudo apt-get update
 
     - uses: r-lib/actions/setup-r-dependencies@v2
       env:
@@ -142,8 +137,8 @@ runs:
         SUMMARY_PATH: ${{ steps.paths.outputs.summary }}
       run: Rscript "${GITHUB_ACTION_PATH}/validate.R"
 
-    # Validation writes no summary if it never got as far as running — a failed
-    # apt update, an r-universe outage. Without this the artifact would carry
+    # Validation writes no summary if it never got as far as running — R failing
+    # to install, an r-universe outage. Without this the artifact would carry
     # nothing to post and the submitter would be back to a bare red cross.
     #
     # Deliberately duplicates the shape summary.R produces: R may never have

--- a/validate-submission/validate-submission.yaml
+++ b/validate-submission/validate-submission.yaml
@@ -35,7 +35,7 @@ jobs:
     # submission is accepted is the one that runs here, on their pull request.
     # Delete this line if your hub does want forks to validate their own copies.
     if: github.event.repository.fork != true
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
 

--- a/validate-target-data/validate-target-data.yaml
+++ b/validate-target-data/validate-target-data.yaml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   validate-target-data:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
@@ -29,13 +29,8 @@ jobs:
 
       - uses: r-lib/actions/setup-r@v2
         with:
-          install-r: false
           use-public-rspm: true
           extra-repositories: 'https://hubverse-org.r-universe.dev'
-
-      - name: Update R
-        run: |
-          sudo apt-get update
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:


### PR DESCRIPTION
> [!WARNING]
> Based on #65, which needs to merge first.

Resolves #64.

`install-r: false` meant our workflows ran on whatever R the runner image happened to provide, which is why they were pinned to `ubuntu-22.04`: it ships R, `ubuntu-24.04` does not. That pin is on a clock — 22.04 deprecation begins 2026-09-17 and it retires on 2027-04-17 — and the dependency underneath it is what broke every hub in #30.

Dropping the override lets `setup-r` install R itself. The runner image stops being load-bearing, so everything moves to `ubuntu-latest` rather than to another pin: these workflows are copied into hub repos rather than referenced, so a pinned runner is a migration that has to reach every hub by hand. The reason we pinned in the first place is gone.

All four actions move together. `setup-r-dependencies` keys its cache on OS and R version, and its `restore-keys` prefix carries the R version too, so there is no partial fallback — if `cache-hubval-deps` and `validate-submission` ever disagree, every submission rebuilds the whole hubValidations tree with nothing reporting it.

`setup-r` runs `apt-get update` as part of installing R, so the separate step each workflow carried for it goes too.

No `r-version` pin; this takes the `release` default. A pin needs a person to remember to bump it and would rot the way the runner pin did, and Posit PPM serves Linux binaries built against current release, so sitting on an old R quietly degrades to source builds.

`hubverse-aws-upload` moves as well. It uses no R so it is outside the issue's scope, but it was on `ubuntu-22.04` and faces the same retirement.

This also covers #61, which asked for `install-r` to be configurable so a hub could run on `ubuntu-latest`. Installing R by default on `ubuntu-latest` gives that directly.

### Cache verification

Two consecutive `test-validate-submission` runs on this branch:

- **Run 1 (cold):** `ubuntu-latest` resolved to Ubuntu 24.04.4, `setup-r` installed R 4.6.1, and all three jobs computed the same key, `Ubuntu 24.04.4 LTS-R version 4.6.1 (2026-06-24)-x86_64-1-de482cbd…`. Not found, built, saved.
- **Run 2 (warm):** all three jobs restored that key, 88 MB.

The `summary` job configures `setup-r` at the workflow level and the `test` jobs get it from the composite action, so this covers the agreement that matters: the shape `cache-hubval-deps` uses and the shape `validate-submission` uses produce one key.
