### PR TITLE
Consolidate the S3 sync into a reusable s3-bucket-upload action

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -25,6 +25,7 @@ consumed by anyone.
 | `test-validate-submission.yaml` | Runs [`validate-submission`](../../validate-submission) against fixture PRs in `ci-testhub-simple`, and its summary rendering against bundled test hubs. |
 | `test-submission-comment.yaml` | Stage 1 of the handoff self-test: uploads a stub result. |
 | `test-submission-comment-post.yaml` | Stage 2: listens for the above finishing and calls the same shared workflow a hub calls. Split in two because a workflow cannot listen to itself. |
+| `test-s3-bucket-upload.yaml` | Runs the shell behind [`s3-bucket-upload`](../../s3-bucket-upload) against fixture hubs, and the action itself against the paths that stop before reaching AWS. |
 
 If you add a reusable workflow here, add it to the first table. If you add CI,
 prefix it `test-` so the distinction keeps holding.

--- a/.github/workflows/test-s3-bucket-upload.yaml
+++ b/.github/workflows/test-s3-bucket-upload.yaml
@@ -1,0 +1,86 @@
+name: Test s3-bucket-upload action
+
+# Self-tests the s3-bucket-upload action (referenced locally). Nothing here
+# reaches a bucket. The `scripts` job runs the shell behind the action against
+# fixture hubs with rclone stubbed out. The `action` job exercises the paths that
+# stop before the sync: cloud storage switched off, a config the action cannot
+# work from, and the default-branch guard.
+
+on:
+  pull_request:
+    paths:
+      - 's3-bucket-upload/**'
+      - '!**/README.md'
+      - '.github/workflows/test-s3-bucket-upload.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  scripts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Check the scripts for shell mistakes
+        run: shellcheck s3-bucket-upload/*.sh s3-bucket-upload/tests/*.sh
+
+      - name: Reading the hub's cloud config
+        run: bash s3-bucket-upload/tests/test-cloud-config.sh
+
+      - name: Syncing directories to the bucket
+        run: bash s3-bucket-upload/tests/test-sync.sh
+
+      - name: Refusing to sync from the wrong branch
+        run: bash s3-bucket-upload/tests/test-check-branch.sh
+
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Run against a hub with cloud storage switched off
+        id: disabled
+        uses: ./s3-bucket-upload
+        with:
+          hub_path: s3-bucket-upload/tests/fixtures/disabled
+
+      - name: Run against a hub whose config gives no bucket
+        id: no-location
+        continue-on-error: true
+        uses: ./s3-bucket-upload
+        with:
+          hub_path: s3-bucket-upload/tests/fixtures/no-location
+
+      # This job runs on a pull request, so a cloud-enabled hub with the guard on
+      # must fail. What the guard refuses is covered by test-check-branch.sh.
+      # This only checks that the action still wires the guard in, and cannot
+      # tell that failure apart from a later one: without `id-token: write` this
+      # job would fail at the AWS step too. Read the log to see which it was.
+      - name: Run with the default-branch guard on, off the default branch
+        id: guard
+        continue-on-error: true
+        uses: ./s3-bucket-upload
+        with:
+          hub_path: s3-bucket-upload/tests/fixtures/enabled
+          enforce_default_branch: true
+
+      - name: Assert each run ended as it should
+        env:
+          DISABLED_BUCKET: ${{ steps.disabled.outputs.storage_location }}
+          NO_LOCATION: ${{ steps.no-location.outcome }}
+          GUARD: ${{ steps.guard.outcome }}
+        run: |
+          status=0
+          check() {
+            [ "$2" = failure ] && return 0
+            echo "$1 should fail the step, got: $2"
+            status=1
+          }
+          check "a config naming no bucket" "$NO_LOCATION"
+          check "the default-branch guard" "$GUARD"
+          if [ -n "$DISABLED_BUCKET" ]; then
+            echo "a hub with cloud storage off should sync nothing, got bucket: $DISABLED_BUCKET"
+            status=1
+          fi
+          exit "$status"

--- a/hubverse-aws-upload/README.md
+++ b/hubverse-aws-upload/README.md
@@ -1,29 +1,40 @@
 # hubverse-aws-upload
 
+Uploads the hub's data to its hubverse-hosted cloud storage on every push to
+`main`, so that what the cloud serves matches the repository.
 
-This action uploads hub data to Hubverse-hosted cloud storage. Currently, the workflow has a single job, `upload`,
-that pushes data to an AWS S3 bucket.
+The workflow's single job, `upload`, calls the
+[`s3-bucket-upload`](../s3-bucket-upload) action, which reads the hub's admin
+config (`admin.json`) and, when `cloud.enabled` is `true`, syncs these
+directories to the S3 bucket named in `cloud.host.storage_location`:
+`auxiliary-data`, `hub-config`, `model-abstracts`, `model-metadata`,
+`target-data` and `model-output`.
 
-The `upload` job perform the following steps:
+This workflow is safe to add to a hub that does not use cloud storage. If the
+admin config has no `cloud` group, or has `cloud.enabled` set to anything other
+than `true`, the job finds nothing to upload and stops before authenticating to
+AWS.
 
-1. Inspect the hub's admin config (`admin.json`) for a `cloud` group.
-2. If `cloud.enabled` is set to `true`:
-    - authenticate to the Hubverse AWS account
-    - use `cloud.host.storage_location` to determine the name of the hub's S3 bucket
-    - sync the following hub directories to the S3 bucket: `auxiliary-data`, `hub-config`, `model-abstracts`, `model-metadata`, `model-output`, `target-data`
+## Setting it up
 
-**Note**: This action is safe to use with non cloud-enabled hubs. 
-If the hub's `admin.config` does not contain a `cloud` group or has `cloud.enabled` set to anything other than `true`,
-the action will skip AWS-related steps.
+From the root of your hub:
 
+```r
+hubCI::use_hub_github_action("hubverse-aws-upload")
+```
+
+Nothing else needs configuring. To change what is uploaded, or to try a sync
+without writing anything, pass the action's inputs from the workflow's `uses:`
+step. [Its README](../s3-bucket-upload#inputs) lists them.
 
 ## AWS setup
 
-Before using this action, a member of the Hubverse development team will need to ["onboard" the hub to AWS](https://github.com/hubverse-org/hubverse-infrastructure?tab=readme-ov-file#onboarding-a-hub). Onboarding is
-a one-time process that creates:
+Before using this workflow, a member of the hubverse development team will need
+to ["onboard" the hub to AWS](https://github.com/hubverse-org/hubverse-infrastructure?tab=readme-ov-file#onboarding-a-hub).
+Onboarding is a one-time process that creates:
 
 - An AWS S3 bucket for the hub
 - A set of AWS permissions that allow the repo's GitHub workflows to write to the bucket
 
-**Important**: The repo's write permissions are limited to the `main` branch. Running this action on another branch
-or on a fork will fail.
+**Important**: The repo's write permissions are limited to the `main` branch.
+Running this workflow on another branch or on a fork will fail.

--- a/hubverse-aws-upload/hubverse-aws-upload.yaml
+++ b/hubverse-aws-upload/hubverse-aws-upload.yaml
@@ -5,78 +5,22 @@ on:
     branches:
       - main
 
-env:
-  # Hubverse AWS account number
-  AWS_ACCOUNT: 767397675902
-
 permissions:
   contents: read
-  # id-token write required for AWS auth
+  # Required to request the hub's AWS role via OpenID Connect.
   id-token: write
 
 jobs:
   upload:
-    # Don't run on forked repositories
+    # Skip forks of the hub. A fork has no AWS role, and its copy of the data is
+    # not what the bucket serves.
     if: github.event.repository.fork != true
     runs-on: ubuntu-latest
-
     steps:
-    - name: Checkout
-      uses: actions/checkout@v7
+      - uses: actions/checkout@v7
 
-    - name: Get hub cloud config
-      # save cloud-related fields from admin config as environment variables
-      # (jq json parser is installed on Github-hosted runners)
-      run: |
-        cloud_enabled=$(cat ./hub-config/admin.json | jq -r '.cloud.enabled') \
-          && echo "CLOUD_ENABLED=$cloud_enabled"
-        cloud_storage_location=$(cat ./hub-config/admin.json | jq -r '.cloud.host.storage_location') \
-          && echo "CLOUD_STORAGE_LOCATION=$cloud_storage_location"
-        echo "CLOUD_ENABLED=$cloud_enabled" >> $GITHUB_ENV
-        echo "CLOUD_STORAGE_LOCATION=$cloud_storage_location" >> $GITHUB_ENV
-
-    - name: Configure AWS credentials
-      # request credentials to assume the hub's AWS role via OpenID Connect
-      if: env.CLOUD_ENABLED == 'true'
-      uses: aws-actions/configure-aws-credentials@v6
-      with:
-        role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT }}:role/${{ env.CLOUD_STORAGE_LOCATION }}
-        aws-region: us-east-1
-
-    - name: Install rclone
-      if: env.CLOUD_ENABLED == 'true'
-      run: |
-        # debian version of rclone is outdated and will result in config name errors
-        # https://github.com/rclone/rclone/issues/6060
-        curl https://rclone.org/install.sh | sudo bash
-        rclone version
-
-    - name: Sync files to cloud storage
-      # sync specified hub directories to S3
-      # (to exclude a directory, remove it from the hub_directories list below)
-      if: env.CLOUD_ENABLED == 'true'
-      run: |
-        hub_directories=(
-          'auxiliary-data'
-          'hub-config'
-          'model-abstracts'
-          'model-metadata'
-          'target-data'
-        )
-        for DIRECTORY in "${hub_directories[@]}"
-        do
-          if [ -d "./$DIRECTORY" ]
-          then
-            rclone sync \
-              "./$DIRECTORY/" \
-              ":s3,provider=AWS,env_auth:$BUCKET_NAME/$DIRECTORY" \
-              --checksum --verbose --stats-one-line --config=/dev/null
-          fi
-        done
-        # unlike other data, model-outputs are synced to a "raw" location
-        # so we can transform it before presenting to users
-        rclone sync ./model-output/ ":s3,provider=AWS,env_auth:$BUCKET_NAME/raw/model-output" \
-          --checksum --verbose --stats-one-line --config=/dev/null
-      shell: bash
-      env:
-        BUCKET_NAME: ${{ env.CLOUD_STORAGE_LOCATION }}
+      - uses: hubverse-org/hubverse-actions/s3-bucket-upload@main
+        # The hub's admin config decides whether anything is uploaded and to
+        # which bucket, so most hubs need no settings here. The action's inputs
+        # change which directories are synced, and can report what a sync would
+        # change without writing anything. See its README for the full list.

--- a/s3-bucket-upload/README.md
+++ b/s3-bucket-upload/README.md
@@ -1,0 +1,127 @@
+# s3-bucket-upload
+
+Syncs a hub's directories to the hubverse-hosted AWS S3 bucket that serves the
+hub's data, using [rclone](https://rclone.org). The hub's admin config decides
+whether anything is uploaded and to which bucket, so a cloud-enabled hub needs
+no settings, and a hub without cloud storage is unaffected: the action reads the
+config and stops.
+
+Most hubs get this through the [`hubverse-aws-upload`](../hubverse-aws-upload)
+workflow, which is this action with the triggers and permissions already set up.
+Use the action directly when assembling your own workflow, or to upload as one
+step of a larger pipeline.
+
+## Usage
+
+The job needs `id-token: write` to request the hub's AWS role, and a checkout
+for the action to read.
+
+```yaml
+permissions:
+  contents: read
+  id-token: write
+
+steps:
+  - uses: actions/checkout@v7
+
+  - uses: hubverse-org/hubverse-actions/s3-bucket-upload@main
+```
+
+Before this works, a member of the hubverse development team needs to
+["onboard" the hub to AWS](https://github.com/hubverse-org/hubverse-infrastructure?tab=readme-ov-file#onboarding-a-hub).
+That one-time process creates the hub's bucket and the permissions that let the
+hub's workflows write to it. Those permissions cover the hub's default branch
+only, so a sync from anywhere else is refused by AWS.
+
+## Inputs
+
+| Input | Default | Description |
+|---|---|---|
+| `hub_path` | `.` | Path to the hub root, relative to the checkout root. |
+| `cloud_enabled` | *(empty)* | Whether to sync at all. Empty takes it from the hub's admin config. |
+| `storage_location` | *(empty)* | Bucket to sync to. Empty takes it from the hub's admin config. |
+| `directories` | the six directories below | Hub directories to sync, one per line. |
+| `dry_run` | `false` | Report what a sync would change without writing anything. |
+| `enforce_default_branch` | `true` | Fail rather than sync when running from any branch other than the repository's default branch. |
+| `aws_account` | `767397675902` | AWS account the hub's role belongs to. Defaults to the hubverse account. |
+| `aws_region` | `us-east-1` | AWS region the bucket lives in. |
+
+## Outputs
+
+| Output | Description |
+|---|---|
+| `storage_location` | Bucket the action synced to. Empty when cloud storage is not enabled, so a later step can tell that nothing was uploaded. |
+
+## What is uploaded, and where it lands
+
+Each directory is synced to a directory of the same name in the bucket, except
+`model-output`:
+
+| Hub directory | In the bucket |
+|---|---|
+| `auxiliary-data` | `auxiliary-data` |
+| `hub-config` | `hub-config` |
+| `model-abstracts` | `model-abstracts` |
+| `model-metadata` | `model-metadata` |
+| `target-data` | `target-data` |
+| `model-output` | `raw/model-output` |
+
+Model output goes to `raw/` because the hubverse pipeline transforms it into
+the formats the bucket serves and reads it from there. Every other directory is
+served as submitted.
+
+Syncing makes the bucket match the hub, so a file deleted from the hub is
+deleted from the bucket on the next run. A shorter `directories` list leaves a
+directory out altogether, and whatever the bucket already holds for it
+untouched. Directories the hub does not have are skipped, so the default list
+suits a hub with no `model-abstracts`.
+
+## Checking a sync before running it
+
+`dry_run` reports what a sync would change and writes nothing:
+
+```yaml
+- uses: hubverse-org/hubverse-actions/s3-bucket-upload@main
+  with:
+    dry_run: true
+```
+
+A dry run still needs the AWS role, since working out what would change means
+reading the bucket. That is also why it has to run from the default branch: a
+hub's role cannot be assumed from anywhere else, so `enforce_default_branch:
+false` moves the failure from this action to AWS rather than avoiding it.
+
+## Where the settings come from
+
+Whether cloud storage is enabled and which bucket to sync to can each come from
+the hub's admin config or from the matching input, and an input takes precedence
+over the config. A hub normally sets neither and lets its config decide.
+
+`storage_location` sends the sync to a different bucket from the one in the
+config, which is how to sync against a staging bucket. It still has to be a
+bucket the hub's AWS role can write to, which for a hubverse-hosted hub means its
+own. `cloud_enabled` decides whether the sync runs at all, whatever the config
+says.
+
+Together the two inputs also cover a repository with no admin config, since
+neither value is then read from one. If there is no config and neither input is
+set, the action fails: it cannot determine whether cloud storage is enabled.
+
+## Notes
+
+- The action installs rclone from its
+  [official script](https://rclone.org/install/) rather than from apt. The Debian
+  version is [too old](https://github.com/rclone/rclone/issues/6060) to parse the
+  inline connection string the sync uses, and fails with "config name contains
+  invalid characters".
+- `enforce_default_branch` fails the run before it reaches AWS, which is a
+  clearer error than the permission failure AWS returns for the same situation.
+  It applies only to a hub with cloud storage enabled, and is skipped with a
+  warning when the triggering event does not include the repository's default
+  branch.
+- A fork of the hub has no AWS role, so a workflow that may run on forks should
+  skip the job there: `if: github.event.repository.fork != true`.
+- The role assumed to reach the bucket is named after the bucket:
+  `arn:aws:iam::<aws_account>:role/<storage_location>`. Onboarding sets a hub's
+  role up that way, so `aws_account` only reaches an account whose roles follow
+  the same convention.

--- a/s3-bucket-upload/action.yaml
+++ b/s3-bucket-upload/action.yaml
@@ -1,0 +1,111 @@
+name: "Upload hub data to an S3 bucket"
+description: >-
+  Sync a hub's directories to its hubverse-hosted AWS S3 bucket with rclone,
+  taking the bucket from the hub's admin config.
+author: "hubverse"
+
+inputs:
+  hub_path:
+    description: "Path to the hub root, relative to the checkout root."
+    default: "."
+  cloud_enabled:
+    description: >-
+      Whether to sync at all (true/false). Leave empty to read it from the 
+      hub's admin config. Setting it here overrides the config setting.
+    default: ""
+  storage_location:
+    description: >-
+      Bucket to sync to. Leave empty to read it from the hub's admin config.
+      Setting it here overrides the config setting.
+    default: ""
+  directories:
+    description: >-
+      Hub directories to sync, one per line. Each is synced to a directory
+      of the same name in the bucket, except `model-output`, which goes to
+      `raw/model-output`. A directory the hub does not have is skipped.
+    default: |
+      auxiliary-data
+      hub-config
+      model-abstracts
+      model-metadata
+      target-data
+      model-output
+  dry_run:
+    description: >-
+      Report what a sync would change without writing anything to the bucket
+      (true/false).
+    default: "false"
+  enforce_default_branch:
+    description: >-
+      Fail rather than sync when running from any branch other than the
+      repository's default branch (true/false). The bucket holds the hub's
+      canonical data, so this guards against a feature branch overwriting it.
+    default: "true"
+  aws_account:
+    description: >-
+      AWS account the hub's role belongs to. Defaults to the hubverse account.
+    default: "767397675902"
+  aws_region:
+    description: "AWS region the bucket lives in."
+    default: "us-east-1"
+
+outputs:
+  storage_location:
+    description: >-
+      Bucket the action synced to. Empty when cloud storage is not enabled, so
+      a later step can tell that nothing was uploaded.
+    value: ${{ steps.config.outputs.storage_location }}
+
+runs:
+  using: composite
+  steps:
+    - id: config
+      name: Work out whether and where to sync
+      shell: bash
+      env:
+        HUB_PATH: ${{ inputs.hub_path }}
+        CLOUD_ENABLED: ${{ inputs.cloud_enabled }}
+        STORAGE_LOCATION: ${{ inputs.storage_location }}
+        DRY_RUN: ${{ inputs.dry_run }}
+        ENFORCE_DEFAULT_BRANCH: ${{ inputs.enforce_default_branch }}
+      run: bash "${GITHUB_ACTION_PATH}/cloud-config.sh"
+
+    - name: Check this is the default branch
+      if: ${{ inputs.enforce_default_branch == 'true' && steps.config.outputs.cloud_enabled == 'true' }}
+      shell: bash
+      env:
+        REF: ${{ github.ref }}
+        DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+      run: bash "${GITHUB_ACTION_PATH}/check-branch.sh"
+
+    - name: Configure AWS credentials
+      # Request credentials to assume the hub's AWS role via OpenID Connect.
+      # The calling job needs `permissions: id-token: write`.
+      if: ${{ steps.config.outputs.cloud_enabled == 'true' }}
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        role-to-assume: arn:aws:iam::${{ inputs.aws_account }}:role/${{ steps.config.outputs.storage_location }}
+        aws-region: ${{ inputs.aws_region }}
+
+    - name: Install rclone
+      # Install the latest rclone from the official script rather than the apt
+      # package. The Debian version is too old to parse the inline connection
+      # string the sync uses (":s3,provider=AWS,env_auth:...") and fails with
+      # "config name contains invalid characters".
+      # https://github.com/rclone/rclone/issues/6060
+      if: ${{ steps.config.outputs.cloud_enabled == 'true' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        curl -fsSL https://rclone.org/install.sh | sudo bash
+        rclone version
+
+    - name: Sync files to cloud storage
+      if: ${{ steps.config.outputs.cloud_enabled == 'true' }}
+      shell: bash
+      env:
+        HUB_PATH: ${{ inputs.hub_path }}
+        STORAGE_LOCATION: ${{ steps.config.outputs.storage_location }}
+        DIRECTORIES: ${{ inputs.directories }}
+        DRY_RUN: ${{ inputs.dry_run }}
+      run: bash "${GITHUB_ACTION_PATH}/sync.sh"

--- a/s3-bucket-upload/check-branch.sh
+++ b/s3-bucket-upload/check-branch.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Refuse to sync from anywhere other than the repository's default branch.
+set -euo pipefail
+
+# Some events do not include the repository in their payload, which leaves the
+# default branch unknown. Warn rather than fail: there is nothing to compare
+# against, and the run may well be legitimate.
+if [ -z "$DEFAULT_BRANCH" ]; then
+  echo "::warning::s3-bucket-upload: the triggering event does not include the repository's default branch, so \`enforce_default_branch\` was not applied."
+  exit 0
+fi
+
+if [ "$REF" != "refs/heads/$DEFAULT_BRANCH" ]; then
+  echo "::error::s3-bucket-upload: refusing to sync from $REF, which is not the default branch ($DEFAULT_BRANCH). Set \`enforce_default_branch: false\` if this is deliberate."
+  exit 1
+fi
+
+echo "Running from $REF, the default branch."

--- a/s3-bucket-upload/cloud-config.sh
+++ b/s3-bucket-upload/cloud-config.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Determine whether cloud storage is enabled and which bucket to sync to. Both
+# values can come from the hub's admin config or from the action's inputs, and
+# an input takes precedence.
+set -euo pipefail
+
+check_flag() {
+  local input="$1" value="$2"
+  if [ "$value" != "true" ] && [ "$value" != "false" ]; then
+    echo "::error::s3-bucket-upload: \`$input\` takes true or false; got \"$value\"."
+    exit 1
+  fi
+}
+
+# A flag arrives as a string, and every string other than "true" is treated as
+# false. Without this check `dry_run: yes` would sync for real and
+# `enforce_default_branch: yes` would drop the guard, in both cases silently.
+check_flag dry_run "$DRY_RUN"
+check_flag enforce_default_branch "$ENFORCE_DEFAULT_BRANCH"
+# cloud_enabled has no default: an empty value leaves the decision to the config.
+if [ -n "$CLOUD_ENABLED" ]; then
+  check_flag cloud_enabled "$CLOUD_ENABLED"
+fi
+
+write_output() {
+  {
+    echo "cloud_enabled=$1"
+    echo "storage_location=$2"
+  } >> "$GITHUB_OUTPUT"
+}
+
+config_enabled=""
+config_location=""
+admin_config="$HUB_PATH/hub-config/admin.json"
+if [ -f "$admin_config" ]; then
+  # A hub that does not use cloud storage either omits the cloud group from its
+  # admin config or sets cloud.enabled to false. Both are ordinary, so a missing
+  # group means disabled, not a broken config.
+  config_enabled=$(jq -r '.cloud.enabled // false' "$admin_config")
+  config_location=$(jq -r '.cloud.host.storage_location // ""' "$admin_config")
+else
+  echo "No hub config at $admin_config; taking both values from the action's inputs."
+fi
+
+cloud_enabled="${CLOUD_ENABLED:-$config_enabled}"
+if [ -z "$cloud_enabled" ]; then
+  echo "::error::s3-bucket-upload: cannot determine whether cloud storage is enabled. There is no hub config at $admin_config and no \`cloud_enabled\` input. Point \`hub_path\` at the hub root, or set \`cloud_enabled\` and \`storage_location\`."
+  exit 1
+fi
+
+if [ "$cloud_enabled" != "true" ]; then
+  echo "Cloud storage is not enabled. Nothing to sync."
+  write_output false ""
+  exit 0
+fi
+
+storage_location="${STORAGE_LOCATION:-$config_location}"
+if [ -z "$storage_location" ]; then
+  echo "::error::s3-bucket-upload: cloud storage is enabled but no bucket is configured. Set cloud.host.storage_location in $admin_config, or pass the \`storage_location\` input."
+  exit 1
+fi
+
+if [ -n "$STORAGE_LOCATION" ]; then
+  echo "Syncing to $storage_location, set by the \`storage_location\` input."
+else
+  echo "Syncing to $storage_location, set in $admin_config."
+fi
+write_output true "$storage_location"

--- a/s3-bucket-upload/sync.sh
+++ b/s3-bucket-upload/sync.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Sync each of the hub's directories to the bucket.
+set -euo pipefail
+
+dry_run_flag=""
+if [ "$DRY_RUN" = "true" ]; then
+  echo "Dry run: reporting what a sync would change, writing nothing."
+  dry_run_flag="--dry-run"
+fi
+
+# `read` splits the line on whitespace, and strips any that surrounds it.
+while read -r directory extra; do
+  # A blank line leaves both empty, and the input ends with one. Syncing an
+  # empty directory name would send the whole hub to the top of the bucket,
+  # deleting everything already there.
+  if [ -z "$directory" ]; then
+    continue
+  fi
+  # A line holding more than one word would sync the first directory and drop
+  # the rest.
+  if [ -n "$extra" ]; then
+    echo "::error::s3-bucket-upload: \`directories\` takes one directory per line; got \"$directory $extra\"."
+    exit 1
+  fi
+
+  destination="$STORAGE_LOCATION"
+  # The hubverse pipeline transforms model output into the formats the bucket
+  # serves, and reads it from raw/model-output. Every other directory is
+  # served as submitted.
+  if [ "$directory" = "model-output" ]; then
+    destination="$STORAGE_LOCATION/raw"
+  fi
+
+  if [ ! -d "$HUB_PATH/$directory" ]; then
+    echo "No $directory directory in the hub; skipping it."
+    continue
+  fi
+
+  echo "Syncing $directory to $destination/$directory"
+  rclone sync \
+    "$HUB_PATH/$directory/" \
+    ":s3,provider=AWS,env_auth:$destination/$directory" \
+    --checksum --verbose --stats-one-line --config=/dev/null ${dry_run_flag:+"$dry_run_flag"}
+done <<< "$DIRECTORIES"

--- a/s3-bucket-upload/tests/fixtures/disabled/hub-config/admin.json
+++ b/s3-bucket-upload/tests/fixtures/disabled/hub-config/admin.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v5.0.0/admin-schema.json",
+  "cloud": {
+    "enabled": false,
+    "host": {
+      "name": "aws",
+      "storage_location": "test-bucket",
+      "host_path": "test-bucket"
+    }
+  }
+}

--- a/s3-bucket-upload/tests/fixtures/enabled/hub-config/admin.json
+++ b/s3-bucket-upload/tests/fixtures/enabled/hub-config/admin.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v5.0.0/admin-schema.json",
+  "cloud": {
+    "enabled": true,
+    "host": {
+      "name": "aws",
+      "storage_location": "test-bucket",
+      "host_path": "test-bucket"
+    }
+  }
+}

--- a/s3-bucket-upload/tests/fixtures/no-cloud/hub-config/admin.json
+++ b/s3-bucket-upload/tests/fixtures/no-cloud/hub-config/admin.json
@@ -1,0 +1,3 @@
+{
+  "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v5.0.0/admin-schema.json"
+}

--- a/s3-bucket-upload/tests/fixtures/no-location/hub-config/admin.json
+++ b/s3-bucket-upload/tests/fixtures/no-location/hub-config/admin.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v5.0.0/admin-schema.json",
+  "cloud": {
+    "enabled": true,
+    "host": {
+      "name": "aws"
+    }
+  }
+}

--- a/s3-bucket-upload/tests/helpers.sh
+++ b/s3-bucket-upload/tests/helpers.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Reporting shared by the test scripts in this directory. Source it, run cases
+# through the expect_* functions, and end with `finish <suite>`.
+
+failures=0
+
+pass() {
+  echo "ok - $1"
+}
+
+fail() {
+  echo "not ok - $1"
+  shift
+  printf '    %s\n' "$@"
+  failures=$((failures + 1))
+}
+
+# Compare two multi-line values, printing each on one line when they differ so
+# the difference is readable in a workflow log.
+expect_equal() {
+  local case_name="$1" expected="$2" actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    pass "$case_name"
+  else
+    fail "$case_name" \
+      "expected: $(printf '%s' "$expected" | tr '\n' '|')" \
+      "actual:   $(printf '%s' "$actual" | tr '\n' '|')"
+  fi
+}
+
+expect_failure() {
+  local case_name="$1"
+  shift
+  if "$@" > /dev/null 2>&1; then
+    fail "$case_name" "it succeeded, and was expected to fail"
+  else
+    pass "$case_name"
+  fi
+}
+
+finish() {
+  if [ "$failures" -gt 0 ]; then
+    echo "$failures failing case(s)"
+    exit 1
+  fi
+  echo "all $1 cases passed"
+}

--- a/s3-bucket-upload/tests/test-check-branch.sh
+++ b/s3-bucket-upload/tests/test-check-branch.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Checks on the default-branch guard.
+set -uo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=s3-bucket-upload/tests/helpers.sh
+. "$here/helpers.sh"
+script="$here/../check-branch.sh"
+
+# Run the guard for one ref and check both what it decided and what it said, so
+# that a guard which passes for the wrong reason is still caught.
+expect() {
+  local case_name="$1" expected="$2" pattern="$3" ref="$4" default_branch="$5"
+  local output decided
+  if output="$(REF="$ref" DEFAULT_BRANCH="$default_branch" bash "$script" 2>&1)"; then
+    decided=pass
+  else
+    decided=fail
+  fi
+
+  if [ "$decided" != "$expected" ]; then
+    fail "$case_name" "expected the guard to $expected, it $decided" "output: $output"
+    return
+  fi
+  if ! printf '%s' "$output" | grep -q "$pattern"; then
+    fail "$case_name" "expected output matching: $pattern" "actual: $output"
+    return
+  fi
+  pass "$case_name"
+}
+
+expect "the default branch syncs" pass "the default branch" refs/heads/main main
+expect "another branch is refused" fail "refs/heads/a-branch" refs/heads/a-branch main
+expect "a pull request ref is refused" fail "::error::" refs/pull/1/merge main
+expect "a default branch other than main is honoured" pass "the default branch" refs/heads/trunk trunk
+expect "an event with no default branch warns rather than refusing" pass "::warning::" refs/heads/anything ""
+
+finish check-branch

--- a/s3-bucket-upload/tests/test-cloud-config.sh
+++ b/s3-bucket-upload/tests/test-cloud-config.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Checks on what cloud-config.sh makes of a hub's admin config and the action's
+# inputs, which are the two sources of the same two answers.
+set -uo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=s3-bucket-upload/tests/helpers.sh
+. "$here/helpers.sh"
+script="$here/../cloud-config.sh"
+fixtures="$here/fixtures"
+
+# Run cloud-config.sh over a fixture hub and print its step outputs, one
+# `name=value` per line, so a case can assert on them.
+run_config() {
+  local hub_path="$1" cloud_enabled="${2:-}" storage_location="${3:-}" dry_run="${4:-false}"
+  local output status
+  output="$(mktemp)"
+  GITHUB_OUTPUT="$output" HUB_PATH="$hub_path" \
+    CLOUD_ENABLED="$cloud_enabled" STORAGE_LOCATION="$storage_location" \
+    DRY_RUN="$dry_run" ENFORCE_DEFAULT_BRANCH="true" \
+    bash "$script" > /dev/null 2>&1
+  status=$?
+  cat "$output"
+  rm -f "$output"
+  return $status
+}
+
+enabled_at() {
+  printf 'cloud_enabled=true\nstorage_location=%s' "$1"
+}
+
+disabled() {
+  printf 'cloud_enabled=false\nstorage_location='
+}
+
+expect_equal "cloud enabled gives the bucket from the config" \
+  "$(enabled_at test-bucket)" \
+  "$(run_config "$fixtures/enabled")"
+
+expect_equal "cloud disabled syncs nothing" \
+  "$(disabled)" \
+  "$(run_config "$fixtures/disabled")"
+
+expect_equal "no cloud group syncs nothing" \
+  "$(disabled)" \
+  "$(run_config "$fixtures/no-cloud")"
+
+expect_equal "the storage_location input overrides the config's bucket" \
+  "$(enabled_at other-bucket)" \
+  "$(run_config "$fixtures/enabled" "" other-bucket)"
+
+expect_equal "cloud_enabled false overrides a config that enables it" \
+  "$(disabled)" \
+  "$(run_config "$fixtures/enabled" false)"
+
+expect_equal "cloud_enabled true overrides a config that disables it" \
+  "$(enabled_at test-bucket)" \
+  "$(run_config "$fixtures/disabled" true)"
+
+expect_equal "the inputs alone are enough without a hub config" \
+  "$(enabled_at other-bucket)" \
+  "$(run_config "$fixtures/does-not-exist" true other-bucket)"
+
+expect_equal "no hub config and cloud_enabled false syncs nothing" \
+  "$(disabled)" \
+  "$(run_config "$fixtures/does-not-exist" false)"
+
+expect_failure "no hub config and no cloud_enabled input fails" \
+  run_config "$fixtures/does-not-exist"
+
+expect_failure "no hub config and no storage_location input fails" \
+  run_config "$fixtures/does-not-exist" true
+
+expect_failure "cloud enabled with no bucket anywhere fails" \
+  run_config "$fixtures/no-location"
+
+expect_failure "a flag set to something other than true or false fails" \
+  run_config "$fixtures/enabled" "" "" yes
+
+expect_failure "a cloud_enabled input that is neither true nor false fails" \
+  run_config "$fixtures/enabled" yes
+
+finish cloud-config

--- a/s3-bucket-upload/tests/test-sync.sh
+++ b/s3-bucket-upload/tests/test-sync.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Checks on which rclone calls sync.sh makes. rclone is replaced by a stub that
+# records the arguments it was called with, so nothing here touches a bucket.
+set -uo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=s3-bucket-upload/tests/helpers.sh
+. "$here/helpers.sh"
+script="$here/../sync.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+hub="$workdir/hub"
+mkdir -p "$hub/hub-config" "$hub/target-data" "$hub/model-output"
+
+stub_dir="$workdir/bin"
+mkdir -p "$stub_dir"
+cat > "$stub_dir/rclone" <<'STUB'
+#!/usr/bin/env bash
+echo "$*" >> "$RCLONE_LOG"
+STUB
+chmod +x "$stub_dir/rclone"
+
+export RCLONE_LOG="$workdir/rclone.log"
+
+# Run sync.sh against the fixture hub and print one line per rclone call.
+run_sync() {
+  local directories="$1" dry_run="${2:-false}" status
+  : > "$RCLONE_LOG"
+  PATH="$stub_dir:$PATH" \
+    HUB_PATH="$hub" STORAGE_LOCATION="test-bucket" \
+    DIRECTORIES="$directories" DRY_RUN="$dry_run" \
+    bash "$script" > /dev/null 2>&1
+  status=$?
+  cat "$RCLONE_LOG"
+  return $status
+}
+
+flags="--checksum --verbose --stats-one-line --config=/dev/null"
+
+expect_equal "each directory syncs to its own name in the bucket" \
+  "sync $hub/hub-config/ :s3,provider=AWS,env_auth:test-bucket/hub-config $flags
+sync $hub/target-data/ :s3,provider=AWS,env_auth:test-bucket/target-data $flags" \
+  "$(run_sync "$(printf 'hub-config\ntarget-data')")"
+
+expect_equal "model output syncs to raw/" \
+  "sync $hub/model-output/ :s3,provider=AWS,env_auth:test-bucket/raw/model-output $flags" \
+  "$(run_sync "model-output")"
+
+expect_equal "a directory the hub does not have is skipped" \
+  "sync $hub/hub-config/ :s3,provider=AWS,env_auth:test-bucket/hub-config $flags" \
+  "$(run_sync "$(printf 'hub-config\nmodel-abstracts')")"
+
+expect_equal "blank lines are skipped" \
+  "sync $hub/hub-config/ :s3,provider=AWS,env_auth:test-bucket/hub-config $flags" \
+  "$(run_sync "$(printf '\nhub-config\n\n  \n')")"
+
+expect_equal "a dry run passes --dry-run to rclone" \
+  "sync $hub/hub-config/ :s3,provider=AWS,env_auth:test-bucket/hub-config $flags --dry-run" \
+  "$(run_sync "hub-config" true)"
+
+expect_failure "several directories on one line fail" \
+  run_sync "hub-config target-data"
+
+finish sync


### PR DESCRIPTION
Resolves #57.

Moves the rclone install and sync out of `hubverse-aws-upload.yaml` and into a new `s3-bucket-upload` composite action, which the template now calls. A hub's copy of the workflow becomes a checkout and a `uses:`, so it carries one reference we keep current instead of logic that drifts, and a hub assembling its own workflow can call the action directly. Based on @dylanhmorris's [`s3-bucket-upload`](https://github.com/CDCgov/hubhelpr/tree/main/actions/s3-bucket-upload), which is in use on the COVID-19 and RSV forecast hubs.

## The action

Whether cloud storage is enabled and which bucket to sync to each come from the hub's admin config or from the matching input, with an input taking precedence. A hub sets neither and lets its config decide; the two inputs together also cover a repository with no admin config. `directories`, `dry_run`, `enforce_default_branch`, `aws_account` and `aws_region` are inputs as well, and `storage_location` is the one output, empty when nothing was synced.

Three steps that need explaining are in scripts rather than inline in `action.yaml`, so they can be tested without a bucket: `cloud-config.sh` resolves the two values, `check-branch.sh` is the default-branch guard, and `sync.sh` runs the per-directory sync.

This differs from the issue on one point. #57 has the template read `admin.json` and gate on `cloud.enabled`, passing the bucket to the action. Doing it in the action instead keeps the `jq` out of every hub's copied workflow, which is the drift #49 is about, and means a hub already using the `hubhelpr` action migrates by changing the `uses:` line and nothing else.

## Behaviour changes

- A hub with no `model-output` directory is skipped rather than failing the sync, as the other five directories already were.
- A run from anywhere other than the default branch is refused before it reaches AWS. The hub's role only permits writes from the default branch, so this replaces an opaque AWS permission error with a named refusal. `enforce_default_branch: false` turns it off.
- A config that enables cloud storage without naming a bucket fails saying so, instead of trying to assume a role called `null`.

Everything else syncs exactly as before, `model-output` included, which still goes to `raw/model-output`.

## Testing

`test-s3-bucket-upload.yaml` runs shellcheck and 26 cases across the three scripts against fixture hubs, with rclone stubbed out, then runs the action itself against the paths that stop before reaching AWS. Nothing in CI touches a bucket, so the sync against real AWS is the one thing still only covered by using it.
